### PR TITLE
Update canonicalize IVAR test

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/CanonicalizeInductionVariableBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/CanonicalizeInductionVariableBenchmark.java
@@ -61,13 +61,13 @@ public class CanonicalizeInductionVariableBenchmark {
   // java -jar benchmarks/target/benchmarks.jar ".*CanonicalizeInductionVariableBenchmark.*"
 
   @Benchmark
-  public void canonicalize() {
-    auto_canonicalize(length);
+  public long canonicalize() {
+    return auto_canonicalize(length);
   }
 
   @Benchmark
-  public void baseline() {
-    baseline(reducedLength);
+  public long baseline() {
+    return baseline(reducedLength);
   }
 
   private long auto_canonicalize(final long iterations) {

--- a/results/jdk-17/x86_64/graalvm_ee/CanonicalizeInductionVariableBenchmark.out
+++ b/results/jdk-17/x86_64/graalvm_ee/CanonicalizeInductionVariableBenchmark.out
@@ -8,6 +8,6 @@
 # Timeout: 10 min per iteration
 # Threads: 1 thread, will synchronize iterations
 
-Benchmark                                              Mode  Cnt        Score         Error  Units
-CanonicalizeInductionVariableBenchmark.baseline        avgt    5        0.386 ±       0.023  ns/op
-CanonicalizeInductionVariableBenchmark.canonicalize    avgt    5  1600326.919 ± 1952276.645  ns/op
+Benchmark                                            Mode  Cnt        Score      Error  Units
+CanonicalizeInductionVariableBenchmark.baseline      avgt    5        0.387 ±    0.026  ns/op
+CanonicalizeInductionVariableBenchmark.canonicalize  avgt    5  2136968.526 ± 5216.365  ns/op

--- a/results/jdk-17/x86_64/openjdk_hotspot/CanonicalizeInductionVariableBenchmark.out
+++ b/results/jdk-17/x86_64/openjdk_hotspot/CanonicalizeInductionVariableBenchmark.out
@@ -8,6 +8,6 @@
 # Timeout: 10 min per iteration
 # Threads: 1 thread, will synchronize iterations
 
-Benchmark                                              Mode  Cnt        Score      Error  Units
-CanonicalizeInductionVariableBenchmark.baseline        avgt    5        0.397 ±    0.051  ns/op
-CanonicalizeInductionVariableBenchmark.canonicalize    avgt    5  2284123.075 ± 6345.816  ns/op
+Benchmark                                            Mode  Cnt        Score        Error  Units
+CanonicalizeInductionVariableBenchmark.baseline      avgt    5        0.509 ±      0.001  ns/op
+CanonicalizeInductionVariableBenchmark.canonicalize  avgt    5  2149295.644 ± 114246.222  ns/op


### PR DESCRIPTION
Updated test to better emphasize the lack of canonicalize IVAR. Nevertheless Graal JIT performs slightly better.