### PR TITLE
Varargs benchmark update

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/VarArgsBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/VarArgsBenchmark.java
@@ -24,17 +24,41 @@
  */
 package com.ionutbalosin.jvm.performance.benchmarks.compiler;
 
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * This benchmark tests the performance of calling Java methods with up to 10 parameters. It also checks the
+ * performance of using varargs.
+ *
+ * When using explicit arguments, usually the callee is inlined and therefore add operations will take most of the benchmark.
+ * If the callee is not inlined, then the first 5 arguments are passed through registers and the remaining will use the stack.
+ * A static call is emitted to the accumulator method.
+ *
+ * Using varargs in Java will cause the caller to wrap the arguments in an array and pass the array to the callee.
+ * If the callee is inlined, then the array allocation is removed.
+ *
+ * For some reason when using varargs and after a couple of warmup iterations, the JVM will trigger a recompilation
+ * of the JMH stub and inline the @Benchmark method in it. Even though during warmup the callee in the benchmark
+ * (the var_args method) was inlined and the array allocation removed, after recompilation this is no longer the case.
+ * In order to circumvent this, I annotate the varargs @Benchmarks with @CompilerControl.Mode.DONT_INLINE.
+ * This causes the JMH stub to emit an extra call to the actual @Benchmark method.
+ * In order to have a fair comparison with the other scenarios, I annotate all the methods in this class
+ * with @CompilerControl.Mode.DONT_INLINE.
+ *
+ * A simple check to see if the array allocation when using varargs is removed is to run the benchmark with -prof gc.
+ */
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -44,124 +68,240 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class VarArgsBenchmark {
 
-  @Param({"3"})
-  private int param1;
+  private int param1, param2, param3, param4, param5, param6, param7, param8, param9, param10;
 
-  @Param({"5"})
-  private int param2;
-
-  @Param({"7"})
-  private int param3;
-
-  @Param({"9"})
-  private int param4;
-
-  @Param({"11"})
-  private int param5;
-
-  @Param({"13"})
-  private int param6;
-
-  @Param({"15"})
-  private int param7;
-
-  @Param({"17"})
-  private int param8;
-
-  @Param({"19"})
-  private int param9;
-
-  @Param({"21"})
-  private int param10;
+  @Setup
+  public void setup() {
+    Random r = new Random();
+    param1 = r.nextInt();
+    param2 = r.nextInt();
+    param3 = r.nextInt();
+    param4 = r.nextInt();
+    param5 = r.nextInt();
+    param6 = r.nextInt();
+    param7 = r.nextInt();
+    param8 = r.nextInt();
+    param9 = r.nextInt();
+    param10 = r.nextInt();
+  }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_1_param() {
-    return explicit_1_param(param1);
+    return explicit_1_param_accumulator(param1);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_2_params() {
-    return explicit_2_params(param1, param2);
+    return explicit_2_params_accumulator(param1, param2);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_4_params() {
-    return explicit_4_params(param1, param2, param3, param4);
+    return explicit_4_params_accumulator(param1, param2, param3, param4);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_6_params() {
-    return explicit_6_params(param1, param2, param3, param4, param5, param6);
+    return explicit_6_params_accumulator(param1, param2, param3, param4, param5, param6);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_8_params() {
-    return explicit_8_params(param1, param2, param3, param4, param5, param6, param7, param8);
+    return explicit_8_params_accumulator(
+        param1, param2, param3, param4, param5, param6, param7, param8);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int explicit_10_params() {
-    return explicit_10_params(
+    return explicit_10_params_accumulator(
         param1, param2, param3, param4, param5, param6, param7, param8, param9, param10);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_1_param() {
+    return no_inline_explicit_1_param_accumulator(param1);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_2_params() {
+    return no_inline_explicit_2_params_accumulator(param1, param2);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_4_params() {
+    return no_inline_explicit_4_params_accumulator(param1, param2, param3, param4);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_6_params() {
+    return no_inline_explicit_6_params_accumulator(param1, param2, param3, param4, param5, param6);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_8_params() {
+    return no_inline_explicit_8_params_accumulator(
+        param1, param2, param3, param4, param5, param6, param7, param8);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_explicit_10_params() {
+    return no_inline_explicit_10_params_accumulator(
+        param1, param2, param3, param4, param5, param6, param7, param8, param9, param10);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_1_param() {
     return var_args(param1);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_2_params() {
     return var_args(param1, param2);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_4_params() {
     return var_args(param1, param2, param3, param4);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_6_params() {
     return var_args(param1, param2, param3, param4, param5, param6);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_8_params() {
     return var_args(param1, param2, param3, param4, param5, param6, param7, param8);
   }
 
   @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public int var_args_10_params() {
     return var_args(
         param1, param2, param3, param4, param5, param6, param7, param8, param9, param10);
   }
 
-  private int explicit_1_param(int p1) {
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_1_param() {
+    return no_inline_var_args(param1);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_2_params() {
+    return no_inline_var_args(param1, param2);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_4_params() {
+    return no_inline_var_args(param1, param2, param3, param4);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_6_params() {
+    return no_inline_var_args(param1, param2, param3, param4, param5, param6);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_8_params() {
+    return no_inline_var_args(param1, param2, param3, param4, param5, param6, param7, param8);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public int no_inline_var_args_10_params() {
+    return no_inline_var_args(
+        param1, param2, param3, param4, param5, param6, param7, param8, param9, param10);
+  }
+
+  private int explicit_1_param_accumulator(int p1) {
     return p1;
   }
 
-  private int explicit_2_params(int p1, int p2) {
+  private int explicit_2_params_accumulator(int p1, int p2) {
     return p1 + p2;
   }
 
-  private int explicit_4_params(int p1, int p2, int p3, int p4) {
+  private int explicit_4_params_accumulator(int p1, int p2, int p3, int p4) {
     return p1 + p2 + p3 + p4;
   }
 
-  private int explicit_6_params(int p1, int p2, int p3, int p4, int p5, int p6) {
+  private int explicit_6_params_accumulator(int p1, int p2, int p3, int p4, int p5, int p6) {
     return p1 + p2 + p3 + p4 + p5 + p6;
   }
 
-  private int explicit_8_params(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8) {
+  private int explicit_8_params_accumulator(
+      int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8) {
     return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8;
   }
 
-  private int explicit_10_params(
+  private int explicit_10_params_accumulator(
       int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10) {
     return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10;
   }
 
   private int var_args(int... args) {
+    int sum = 0;
+    for (int i = 0; i < args.length; i++) sum += args[i];
+    return sum;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_1_param_accumulator(int p1) {
+    return p1;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_2_params_accumulator(int p1, int p2) {
+    return p1 + p2;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_4_params_accumulator(int p1, int p2, int p3, int p4) {
+    return p1 + p2 + p3 + p4;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_6_params_accumulator(
+      int p1, int p2, int p3, int p4, int p5, int p6) {
+    return p1 + p2 + p3 + p4 + p5 + p6;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_8_params_accumulator(
+      int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8) {
+    return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_explicit_10_params_accumulator(
+      int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10) {
+    return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10;
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int no_inline_var_args(int... args) {
     int sum = 0;
     for (int i = 0; i < args.length; i++) sum += args[i];
     return sum;


### PR DESCRIPTION
Results:

GraalVM CE:
```
Benchmark                                      (param1)  (param10)  (param2)  (param3)  (param4)  (param5)  (param6)  (param7)  (param8)  (param9)  Mode  Cnt   Score    Error  Units
VarArgsBenchmark.explicit_10_params                   3         21         5         7         9        11        13        15        17        19  avgt    6   2.501 ±  0.070  ns/op
VarArgsBenchmark.explicit_1_param                     3         21         5         7         9        11        13        15        17        19  avgt    6   1.766 ±  0.001  ns/op
VarArgsBenchmark.explicit_2_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   1.766 ±  0.001  ns/op
VarArgsBenchmark.explicit_4_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   1.781 ±  0.030  ns/op
VarArgsBenchmark.explicit_6_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   2.068 ±  0.024  ns/op
VarArgsBenchmark.explicit_8_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   2.219 ±  0.020  ns/op
VarArgsBenchmark.no_inline_explicit_10_params         3         21         5         7         9        11        13        15        17        19  avgt    6   4.739 ±  0.359  ns/op
VarArgsBenchmark.no_inline_explicit_1_param           3         21         5         7         9        11        13        15        17        19  avgt    6   2.945 ±  0.007  ns/op
VarArgsBenchmark.no_inline_explicit_2_params          3         21         5         7         9        11        13        15        17        19  avgt    6   2.944 ±  0.001  ns/op
VarArgsBenchmark.no_inline_explicit_4_params          3         21         5         7         9        11        13        15        17        19  avgt    6   2.946 ±  0.008  ns/op
VarArgsBenchmark.no_inline_explicit_6_params          3         21         5         7         9        11        13        15        17        19  avgt    6   3.534 ±  0.004  ns/op
VarArgsBenchmark.no_inline_explicit_8_params          3         21         5         7         9        11        13        15        17        19  avgt    6   3.993 ±  0.040  ns/op
VarArgsBenchmark.no_inline_var_args_10_params         3         21         5         7         9        11        13        15        17        19  avgt    6  10.579 ±  0.014  ns/op
VarArgsBenchmark.no_inline_var_args_1_param           3         21         5         7         9        11        13        15        17        19  avgt    6   4.564 ±  0.004  ns/op
VarArgsBenchmark.no_inline_var_args_2_params          3         21         5         7         9        11        13        15        17        19  avgt    6   4.875 ±  0.054  ns/op
VarArgsBenchmark.no_inline_var_args_4_params          3         21         5         7         9        11        13        15        17        19  avgt    6   6.124 ±  0.009  ns/op
VarArgsBenchmark.no_inline_var_args_6_params          3         21         5         7         9        11        13        15        17        19  avgt    6   8.149 ±  0.104  ns/op
VarArgsBenchmark.no_inline_var_args_8_params          3         21         5         7         9        11        13        15        17        19  avgt    6   9.378 ±  0.110  ns/op
VarArgsBenchmark.var_args_10_params                   3         21         5         7         9        11        13        15        17        19  avgt    6   2.497 ±  0.052  ns/op
VarArgsBenchmark.var_args_1_param                     3         21         5         7         9        11        13        15        17        19  avgt    6   1.766 ±  0.001  ns/op
VarArgsBenchmark.var_args_2_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   1.766 ±  0.001  ns/op
VarArgsBenchmark.var_args_4_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   1.777 ±  0.009  ns/op
VarArgsBenchmark.var_args_6_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   2.078 ±  0.033  ns/op
VarArgsBenchmark.var_args_8_params                    3         21         5         7         9        11        13        15        17        19  avgt    6   2.221 ±  0.080  ns/op
```

OpenJDK 17:
```
Benchmark                                      (param1)  (param10)  (param2)  (param3)  (param4)  (param5)  (param6)  (param7)  (param8)  (param9)  Mode  Cnt  Score    Error  Units
VarArgsBenchmark.explicit_10_params                   3         21         5         7         9        11        13        15        17        19  avgt    6  2.498 ±  0.027  ns/op
VarArgsBenchmark.explicit_1_param                     3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.001  ns/op
VarArgsBenchmark.explicit_2_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.001  ns/op
VarArgsBenchmark.explicit_4_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.001  ns/op
VarArgsBenchmark.explicit_6_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.061 ±  0.003  ns/op
VarArgsBenchmark.explicit_8_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.686 ±  1.413  ns/op
VarArgsBenchmark.no_inline_explicit_10_params         3         21         5         7         9        11        13        15        17        19  avgt    6  4.432 ±  0.067  ns/op
VarArgsBenchmark.no_inline_explicit_1_param           3         21         5         7         9        11        13        15        17        19  avgt    6  3.237 ±  0.001  ns/op
VarArgsBenchmark.no_inline_explicit_2_params          3         21         5         7         9        11        13        15        17        19  avgt    6  3.237 ±  0.001  ns/op
VarArgsBenchmark.no_inline_explicit_4_params          3         21         5         7         9        11        13        15        17        19  avgt    6  3.237 ±  0.001  ns/op
VarArgsBenchmark.no_inline_explicit_6_params          3         21         5         7         9        11        13        15        17        19  avgt    6  3.241 ±  0.012  ns/op
VarArgsBenchmark.no_inline_explicit_8_params          3         21         5         7         9        11        13        15        17        19  avgt    6  3.828 ±  0.003  ns/op
VarArgsBenchmark.no_inline_var_args_10_params         3         21         5         7         9        11        13        15        17        19  avgt    6  8.112 ±  0.041  ns/op
VarArgsBenchmark.no_inline_var_args_1_param           3         21         5         7         9        11        13        15        17        19  avgt    6  4.560 ±  0.005  ns/op
VarArgsBenchmark.no_inline_var_args_2_params          3         21         5         7         9        11        13        15        17        19  avgt    6  5.149 ±  0.020  ns/op
VarArgsBenchmark.no_inline_var_args_4_params          3         21         5         7         9        11        13        15        17        19  avgt    6  5.607 ±  0.009  ns/op
VarArgsBenchmark.no_inline_var_args_6_params          3         21         5         7         9        11        13        15        17        19  avgt    6  6.963 ±  0.030  ns/op
VarArgsBenchmark.no_inline_var_args_8_params          3         21         5         7         9        11        13        15        17        19  avgt    6  7.844 ±  0.019  ns/op
VarArgsBenchmark.var_args_10_params                   3         21         5         7         9        11        13        15        17        19  avgt    6  2.487 ±  0.020  ns/op
VarArgsBenchmark.var_args_1_param                     3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.002  ns/op
VarArgsBenchmark.var_args_2_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.001  ns/op
VarArgsBenchmark.var_args_4_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.060 ±  0.001  ns/op
VarArgsBenchmark.var_args_6_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.061 ±  0.002  ns/op
VarArgsBenchmark.var_args_8_params                    3         21         5         7         9        11        13        15        17        19  avgt    6  2.231 ±  0.006  ns/op
```