### PR TITLE
Add an infrastructure benchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/InfrastructureBaselineBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/InfrastructureBaselineBenchmark.java
@@ -1,0 +1,140 @@
+/**
+ *  JVM Performance Benchmarks
+ *
+ *  Copyright (C) 2019 - 2022 Ionut Balosin
+ *  Website: www.ionutbalosin.com
+ *  Twitter: @ionutbalosin
+ *
+ *  Co-author: Florin Blanaru
+ *  Twitter: @gigiblender
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.ionutbalosin.jvm.performance.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/*
+ * This benchmark is used as a baseline (i.e., a preliminary check) to assess the infrastructure overhead for the code to measure.
+ * Since no magical infrastructures are incurring no overhead, it is essential to know what default overheads might occur in our setup.
+ * It measures the calls performance of empty methods (w/ and w/o explicit inlining) but also the performance of
+ * returning an object versus consuming it via black holes. All of these mechanisms are used inside the real suite of tests.
+ *
+ * This benchmark is particularly useful in case of a comparison between different types of JVMs, and it should be run
+ * before any other real benchmark to check the default costs.
+ *
+ * Note: A comparison between different JVMs might not be further relevant unless, at least, the baseline is the same.
+ *
+ * References:
+ * - https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_01_HelloWorld.java
+ * - https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_16_CompilerControl.java
+ * - https://shipilev.net/jvm/anatomy-quarks/27-compiler-blackholes
+ */
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
+@State(Scope.Benchmark)
+public class InfrastructureBaselineBenchmark {
+
+  // java -jar benchmarks/target/benchmarks.jar ".*InfrastructureBaselineBenchmark.*"
+  // JMH Opts: -prof perfnorm
+
+  public Object object;
+
+  /*
+   * The performance of below methods should be the same:
+   * - method_baseline()
+   * - method_blank()
+   * - method_inline()
+   *
+   * The cost of method_dont_inline() is slightly higher.
+   */
+
+  @Benchmark
+  public void method_baseline() {
+    // this method was intentionally left blank
+  }
+
+  @Benchmark
+  public void method_blank() {
+    target_blank();
+  }
+
+  @Benchmark
+  public void method_inline() {
+    target_inline();
+  }
+
+  @Benchmark
+  public void method_dont_inline() {
+    target_dont_inline();
+  }
+
+  /*
+   * The performance of below methods should be the same:
+   * - obj_return()
+   * - obj_blackhole_consume()
+   *
+   * The cost of obj_sink() is slightly higher.
+   */
+
+  @Benchmark
+  public Object obj_return() {
+    return object;
+  }
+
+  @Benchmark
+  public void obj_blackhole_consume(Blackhole bh) {
+    bh.consume(object);
+  }
+
+  @Benchmark
+  public void obj_sink() {
+    sink(object);
+  }
+
+  private void target_blank() {
+    // this method was intentionally left blank
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private void target_dont_inline() {
+    // this method was intentionally left blank
+  }
+
+  @CompilerControl(CompilerControl.Mode.INLINE)
+  private void target_inline() {
+    // this method was intentionally left blank
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private void sink(Object object) {
+    // this method was intentionally left blank
+  }
+}

--- a/results/jdk-17/x86_64/eclipse_openj9/InfrastructureBaselineBenchmark.out
+++ b/results/jdk-17/x86_64/eclipse_openj9/InfrastructureBaselineBenchmark.out
@@ -1,0 +1,166 @@
+# JMH version: 1.35
+# VM version: JDK 17.0.2, Eclipse OpenJ9 VM, openj9-0.30.0
+# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
+# VM invoker: /usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/bin/java
+# VM options: -Xoptionsfile=/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib/options.default -Xlockword:mode=default,noLockword=java/lang/String,noLockword=java/util/MapEntry,noLockword=java/util/HashMap$Entry,noLockword=org/apache/harmony/luni/util/ModifiedMap$Entry,noLockword=java/util/Hashtable$Entry,noLockword=java/lang/invoke/MethodType,noLockword=java/lang/invoke/MethodHandle,noLockword=java/lang/invoke/CollectHandle,noLockword=java/lang/invoke/ConstructorHandle,noLockword=java/lang/invoke/ConvertHandle,noLockword=java/lang/invoke/ArgumentConversionHandle,noLockword=java/lang/invoke/AsTypeHandle,noLockword=java/lang/invoke/ExplicitCastHandle,noLockword=java/lang/invoke/FilterReturnHandle,noLockword=java/lang/invoke/DirectHandle,noLockword=java/lang/invoke/ReceiverBoundHandle,noLockword=java/lang/invoke/DynamicInvokerHandle,noLockword=java/lang/invoke/FieldHandle,noLockword=java/lang/invoke/FieldGetterHandle,noLockword=java/lang/invoke/FieldSetterHandle,noLockword=java/lang/invoke/StaticFieldGetterHandle,noLockword=java/lang/invoke/StaticFieldSetterHandle,noLockword=java/lang/invoke/IndirectHandle,noLockword=java/lang/invoke/InterfaceHandle,noLockword=java/lang/invoke/VirtualHandle,noLockword=java/lang/invoke/PrimitiveHandle,noLockword=java/lang/invoke/InvokeExactHandle,noLockword=java/lang/invoke/InvokeGenericHandle,noLockword=java/lang/invoke/VarargsCollectorHandle,noLockword=java/lang/invoke/ThunkTuple -Xjcl:jclse29 -Dcom.ibm.oti.vm.bootstrap.library.path=/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib/default:/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib -Dsun.boot.library.path=/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib/default:/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib -Djava.library.path=/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib/default:/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8/lib:/usr/lib64:/usr/lib -Djava.home=/usr/lib/jvm/ibm-semeru-openj9-jdk-17.0.2+8 -Duser.dir=/home/ionutbalosin/Workspace/jvm-performance-benchmarks -Djava.class.path=benchmarks/target/benchmarks.jar -Dsun.java.command=benchmarks/target/benchmarks.jar .*InfrastructureBaselineBenchmark.* -f 1 -prof perfnorm -Dsun.java.launcher=SUN_STANDARD
+# Blackhole mode: full + dont-inline hint (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
+# Warmup: 5 iterations, 10 s each
+# Measurement: 5 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+
+Benchmark                                                                    Mode  Cnt   Score   Error      Units
+InfrastructureBaselineBenchmark.method_baseline                              avgt    5   0.400 ± 0.008      ns/op
+InfrastructureBaselineBenchmark.method_baseline:CPI                          avgt        0.401          clks/insn
+InfrastructureBaselineBenchmark.method_baseline:IPC                          avgt        2.492          insns/clk
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-load-misses        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-loads              avgt        1.252               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-stores             avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-icache-load-misses        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-load-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-loads                    avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-store-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-stores                   avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:branch-misses                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:branches                     avgt        1.503               #/op
+InfrastructureBaselineBenchmark.method_baseline:cycles                       avgt        1.508               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-load-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-loads                   avgt        1.252               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-store-misses            avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-stores                  avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-load-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-loads                   avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:instructions                 avgt        3.758               #/op
+
+InfrastructureBaselineBenchmark.method_blank                                 avgt    5   0.408 ± 0.002      ns/op
+InfrastructureBaselineBenchmark.method_blank:CPI                             avgt        0.402          clks/insn
+InfrastructureBaselineBenchmark.method_blank:IPC                             avgt        2.489          insns/clk
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-load-misses           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-loads                 avgt        1.250               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-stores                avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-icache-load-misses           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-load-misses                 avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-loads                       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-store-misses                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-stores                      avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:branch-misses                   avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:branches                        avgt        1.499               #/op
+InfrastructureBaselineBenchmark.method_blank:cycles                          avgt        1.507               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-load-misses                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-loads                      avgt        1.251               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-store-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-stores                     avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-loads                      avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:instructions                    avgt        3.751               #/op
+
+InfrastructureBaselineBenchmark.method_dont_inline                           avgt    5   0.411 ± 0.002      ns/op
+InfrastructureBaselineBenchmark.method_dont_inline:CPI                       avgt        0.401          clks/insn
+InfrastructureBaselineBenchmark.method_dont_inline:IPC                       avgt        2.492          insns/clk
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-load-misses     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-loads           avgt        1.253               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-stores          avgt        0.002               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-icache-load-misses     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-load-misses           avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-loads                 avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-store-misses          avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-stores                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branch-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branches                  avgt        1.503               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:cycles                    avgt        1.509               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-load-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-loads                avgt        1.251               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-store-misses         avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-stores               avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-load-misses          avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-loads                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:instructions              avgt        3.761               #/op
+
+InfrastructureBaselineBenchmark.method_inline                                avgt    5   0.412 ± 0.012      ns/op
+InfrastructureBaselineBenchmark.method_inline:CPI                            avgt        0.401          clks/insn
+InfrastructureBaselineBenchmark.method_inline:IPC                            avgt        2.491          insns/clk
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-load-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-loads                avgt        1.252               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-stores               avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-icache-load-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-loads                      avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-store-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-stores                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:branch-misses                  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:branches                       avgt        1.502               #/op
+InfrastructureBaselineBenchmark.method_inline:cycles                         avgt        1.510               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-loads                     avgt        1.253               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-store-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-stores                    avgt        0.001               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-loads                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:instructions                   avgt        3.761               #/op
+
+InfrastructureBaselineBenchmark.obj_blackhole_consume                        avgt    5   2.201 ± 0.227      ns/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:CPI                    avgt        0.691          clks/insn
+InfrastructureBaselineBenchmark.obj_blackhole_consume:IPC                    avgt        1.447          insns/clk
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-load-misses  avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-loads        avgt        4.009               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-stores       avgt        1.004               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-icache-load-misses  avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-load-misses        avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-loads              avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-store-misses       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-stores             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branch-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branches               avgt        3.006               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:cycles                 avgt        8.139               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-load-misses       avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-loads             avgt        4.012               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-store-misses      avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-stores            avgt        1.005               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-load-misses       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-loads             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:instructions           avgt       11.778               #/op
+
+InfrastructureBaselineBenchmark.obj_return                                   avgt    5   1.967 ± 0.013      ns/op
+InfrastructureBaselineBenchmark.obj_return:CPI                               avgt        0.511          clks/insn
+InfrastructureBaselineBenchmark.obj_return:IPC                               avgt        1.955          insns/clk
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-load-misses             avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-loads                   avgt        5.006               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-stores                  avgt        1.003               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-icache-load-misses             avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-load-misses                   avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-loads                         avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-store-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-stores                        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:branch-misses                     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:branches                          avgt        3.013               #/op
+InfrastructureBaselineBenchmark.obj_return:cycles                            avgt        7.054               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-load-misses                  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-loads                        avgt        5.022               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-store-misses                 avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-stores                       avgt        1.006               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-load-misses                  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-loads                        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:instructions                      avgt       13.792               #/op
+
+InfrastructureBaselineBenchmark.obj_sink                                     avgt    5   0.435 ± 0.002      ns/op
+InfrastructureBaselineBenchmark.obj_sink:CPI                                 avgt        0.401          clks/insn
+InfrastructureBaselineBenchmark.obj_sink:IPC                                 avgt        2.493          insns/clk
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-load-misses               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-loads                     avgt        1.252               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-stores                    avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-icache-load-misses               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-load-misses                     avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-loads                           avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-store-misses                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-stores                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branch-misses                       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branches                            avgt        1.502               #/op
+InfrastructureBaselineBenchmark.obj_sink:cycles                              avgt        1.507               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-load-misses                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-loads                          avgt        1.247               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-store-misses                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-stores                         avgt        0.001               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-load-misses                    avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-loads                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:instructions                        avgt        3.757               #/op

--- a/results/jdk-17/x86_64/graalvm_ee/InfrastructureBaselineBenchmark.out
+++ b/results/jdk-17/x86_64/graalvm_ee/InfrastructureBaselineBenchmark.out
@@ -1,0 +1,164 @@
+# JMH version: 1.35
+# VM version: JDK 17.0.4.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.4.1+1-LTS-jvmci-22.2-b08
+# VM invoker: /usr/lib/jvm/graalvm-ee-java17-22.2.0.1/bin/java
+# VM options: -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCIProduct -XX:-UnlockExperimentalVMOptions
+# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
+# Warmup: 5 iterations, 10 s each
+# Measurement: 5 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+
+Benchmark                                                                    Mode  Cnt   Score   Error      Units
+InfrastructureBaselineBenchmark.method_baseline                              avgt    5   0.415 ± 0.005      ns/op
+InfrastructureBaselineBenchmark.method_baseline:CPI                          avgt        0.301          clks/insn
+InfrastructureBaselineBenchmark.method_baseline:IPC                          avgt        3.325          insns/clk
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-load-misses        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-loads              avgt        2.998               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-stores             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-icache-load-misses        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-load-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-loads                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-store-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-stores                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:branch-misses                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:branches                     avgt        1.001               #/op
+InfrastructureBaselineBenchmark.method_baseline:cycles                       avgt        1.505               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-load-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-loads                   avgt        3.003               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-store-misses            avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-stores                  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-load-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-loads                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:instructions                 avgt        5.004               #/op
+
+InfrastructureBaselineBenchmark.method_blank                                 avgt    5   0.424 ± 0.002      ns/op
+InfrastructureBaselineBenchmark.method_blank:CPI                             avgt        0.301          clks/insn
+InfrastructureBaselineBenchmark.method_blank:IPC                             avgt        3.323          insns/clk
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-load-misses           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-loads                 avgt        3.001               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-stores                avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-icache-load-misses           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-load-misses                 avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-loads                       avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-store-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-stores                      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:branch-misses                   avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:branches                        avgt        1.000               #/op
+InfrastructureBaselineBenchmark.method_blank:cycles                          avgt        1.505               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-loads                      avgt        3.002               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-store-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-stores                     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-loads                      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:instructions                    avgt        5.001               #/op
+
+InfrastructureBaselineBenchmark.method_dont_inline                           avgt    5   1.560 ± 0.141      ns/op
+InfrastructureBaselineBenchmark.method_dont_inline:CPI                       avgt        0.343          clks/insn
+InfrastructureBaselineBenchmark.method_dont_inline:IPC                       avgt        2.917          insns/clk
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-load-misses     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-loads           avgt        8.999               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-stores          avgt        2.001               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-icache-load-misses     avgt       ≈ 10⁻³               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-load-misses           avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-loads                 avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-store-misses          avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-stores                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branch-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branches                  avgt        3.000               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:cycles                    avgt        5.483               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-load-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-loads                avgt        9.000               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-store-misses         avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-stores               avgt        1.998               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-load-misses          avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-loads                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:instructions              avgt       15.995               #/op
+
+InfrastructureBaselineBenchmark.method_inline                                avgt    5   0.432 ± 0.020      ns/op
+InfrastructureBaselineBenchmark.method_inline:CPI                            avgt        0.301          clks/insn
+InfrastructureBaselineBenchmark.method_inline:IPC                            avgt        3.325          insns/clk
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-load-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-loads                avgt        2.999               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-stores               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-icache-load-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-load-misses                avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-loads                      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-store-misses               avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-stores                     avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:branch-misses                  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:branches                       avgt        0.999               #/op
+InfrastructureBaselineBenchmark.method_inline:cycles                         avgt        1.504               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-loads                     avgt        3.000               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-store-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-stores                    avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-loads                     avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:instructions                   avgt        5.001               #/op
+
+InfrastructureBaselineBenchmark.obj_blackhole_consume                        avgt    5   0.556 ± 0.096      ns/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:CPI                    avgt        0.286          clks/insn
+InfrastructureBaselineBenchmark.obj_blackhole_consume:IPC                    avgt        3.494          insns/clk
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-load-misses  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-loads        avgt        3.998               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-stores       avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-icache-load-misses  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-load-misses        avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-loads              avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-store-misses       avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-stores             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branch-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branches               avgt        1.000               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:cycles                 avgt        2.002               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-load-misses       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-loads             avgt        3.989               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-store-misses      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-stores            avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-load-misses       avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-loads             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:instructions           avgt        6.996               #/op
+
+InfrastructureBaselineBenchmark.obj_return                                   avgt    5   0.552 ± 0.062      ns/op
+InfrastructureBaselineBenchmark.obj_return:CPI                               avgt        0.286          clks/insn
+InfrastructureBaselineBenchmark.obj_return:IPC                               avgt        3.492          insns/clk
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-load-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-loads                   avgt        3.999               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-stores                  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-icache-load-misses             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-load-misses                   avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-loads                         avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-store-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-stores                        avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:branch-misses                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:branches                          avgt        0.999               #/op
+InfrastructureBaselineBenchmark.obj_return:cycles                            avgt        2.000               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-load-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-loads                        avgt        4.002               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-store-misses                 avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-stores                       avgt       ≈ 10⁻³               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-load-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-loads                        avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:instructions                      avgt        6.986               #/op
+
+InfrastructureBaselineBenchmark.obj_sink                                     avgt    5   1.649 ± 0.004      ns/op
+InfrastructureBaselineBenchmark.obj_sink:CPI                                 avgt        0.300          clks/insn
+InfrastructureBaselineBenchmark.obj_sink:IPC                                 avgt        3.328          insns/clk
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-load-misses               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-loads                     avgt        9.995               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-stores                    avgt        2.002               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-icache-load-misses               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-load-misses                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-loads                           avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-store-misses                    avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-stores                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branch-misses                       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branches                            avgt        2.998               #/op
+InfrastructureBaselineBenchmark.obj_sink:cycles                              avgt        6.005               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-load-misses                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-loads                          avgt        9.981               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-store-misses                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-stores                         avgt        1.997               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-load-misses                    avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-loads                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:instructions                        avgt       19.985               #/op

--- a/results/jdk-17/x86_64/openjdk_hotspot/InfrastructureBaselineBenchmark.out
+++ b/results/jdk-17/x86_64/openjdk_hotspot/InfrastructureBaselineBenchmark.out
@@ -1,0 +1,165 @@
+# JMH version: 1.35
+# VM version: JDK 17.0.2, OpenJDK 64-Bit Server VM, 17.0.2+8-86
+# VM invoker: /usr/lib/jvm/openjdk-17.0.2/bin/java
+# VM options: <none>
+# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
+# Warmup: 5 iterations, 10 s each
+# Measurement: 5 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+
+Benchmark                                                                    Mode  Cnt   Score   Error      Units
+InfrastructureBaselineBenchmark.method_baseline                              avgt    5   0.404 ± 0.051      ns/op
+InfrastructureBaselineBenchmark.method_baseline:CPI                          avgt        0.251          clks/insn
+InfrastructureBaselineBenchmark.method_baseline:IPC                          avgt        3.983          insns/clk
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-load-misses        avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-loads              avgt        3.001               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-dcache-stores             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:L1-icache-load-misses        avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-load-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-loads                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-store-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:LLC-stores                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:branch-misses                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_baseline:branches                     avgt        1.000               #/op
+InfrastructureBaselineBenchmark.method_baseline:cycles                       avgt        1.506               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-load-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-loads                   avgt        2.996               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-store-misses            avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:dTLB-stores                  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-load-misses             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:iTLB-loads                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_baseline:instructions                 avgt        5.998               #/op
+
+InfrastructureBaselineBenchmark.method_blank                                 avgt    5   0.401 ± 0.060      ns/op
+InfrastructureBaselineBenchmark.method_blank:CPI                             avgt        0.251          clks/insn
+InfrastructureBaselineBenchmark.method_blank:IPC                             avgt        3.991          insns/clk
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-load-misses           avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-loads                 avgt        3.004               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-dcache-stores                avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:L1-icache-load-misses           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-load-misses                 avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-loads                       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-store-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:LLC-stores                      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:branch-misses                   avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_blank:branches                        avgt        1.002               #/op
+InfrastructureBaselineBenchmark.method_blank:cycles                          avgt        1.506               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-loads                      avgt        3.002               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-store-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:dTLB-stores                     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:iTLB-loads                      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_blank:instructions                    avgt        6.011               #/op
+
+InfrastructureBaselineBenchmark.method_dont_inline                           avgt    5   1.781 ± 0.219      ns/op
+InfrastructureBaselineBenchmark.method_dont_inline:CPI                       avgt        0.365          clks/insn
+InfrastructureBaselineBenchmark.method_dont_inline:IPC                       avgt        2.740          insns/clk
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-load-misses     avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-loads           avgt        8.000               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-dcache-stores          avgt        2.002               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:L1-icache-load-misses     avgt       ≈ 10⁻³               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-load-misses           avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-loads                 avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-store-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:LLC-stores                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branch-misses             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:branches                  avgt        4.003               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:cycles                    avgt        6.213               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-load-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-loads                avgt        8.012               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-store-misses         avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:dTLB-stores               avgt        2.004               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-load-misses          avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:iTLB-loads                avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_dont_inline:instructions              avgt       17.023               #/op
+
+InfrastructureBaselineBenchmark.method_inline                                avgt    5   0.407 ± 0.005      ns/op
+InfrastructureBaselineBenchmark.method_inline:CPI                            avgt        0.251          clks/insn
+InfrastructureBaselineBenchmark.method_inline:IPC                            avgt        3.985          insns/clk
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-load-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-loads                avgt        3.003               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-dcache-stores               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:L1-icache-load-misses          avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-load-misses                avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-loads                      avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-store-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:LLC-stores                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:branch-misses                  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.method_inline:branches                       avgt        1.001               #/op
+InfrastructureBaselineBenchmark.method_inline:cycles                         avgt        1.507               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-loads                     avgt        3.004               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-store-misses              avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:dTLB-stores                    avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-load-misses               avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:iTLB-loads                     avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.method_inline:instructions                   avgt        6.005               #/op
+
+InfrastructureBaselineBenchmark.obj_blackhole_consume                        avgt    5   0.544 ± 0.001      ns/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:CPI                    avgt        0.251          clks/insn
+InfrastructureBaselineBenchmark.obj_blackhole_consume:IPC                    avgt        3.992          insns/clk
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-load-misses  avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-loads        avgt        4.005               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-dcache-stores       avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:L1-icache-load-misses  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-load-misses        avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-loads              avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-store-misses       avgt       ≈ 10⁻⁷               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:LLC-stores             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branch-misses          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:branches               avgt        1.002               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:cycles                 avgt        2.007               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-load-misses       avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-loads             avgt        4.005               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-store-misses      avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:dTLB-stores            avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-load-misses       avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:iTLB-loads             avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_blackhole_consume:instructions           avgt        8.012               #/op
+
+InfrastructureBaselineBenchmark.obj_return                                   avgt    5   0.548 ± 0.059      ns/op
+InfrastructureBaselineBenchmark.obj_return:CPI                               avgt        0.251          clks/insn
+InfrastructureBaselineBenchmark.obj_return:IPC                               avgt        3.990          insns/clk
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-load-misses             avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-loads                   avgt        4.001               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-dcache-stores                  avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:L1-icache-load-misses             avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-load-misses                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-loads                         avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-store-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:LLC-stores                        avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:branch-misses                     avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_return:branches                          avgt        1.001               #/op
+InfrastructureBaselineBenchmark.obj_return:cycles                            avgt        2.007               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-load-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-loads                        avgt        4.000               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-store-misses                 avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:dTLB-stores                       avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-load-misses                  avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:iTLB-loads                        avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_return:instructions                      avgt        8.008               #/op
+
+InfrastructureBaselineBenchmark.obj_sink                                     avgt    5   1.734 ± 0.029      ns/op
+InfrastructureBaselineBenchmark.obj_sink:CPI                                 avgt        0.294          clks/insn
+InfrastructureBaselineBenchmark.obj_sink:IPC                                 avgt        3.403          insns/clk
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-load-misses               avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-loads                     avgt       10.012               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-dcache-stores                    avgt        2.002               #/op
+InfrastructureBaselineBenchmark.obj_sink:L1-icache-load-misses               avgt       ≈ 10⁻³               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-load-misses                     avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-loads                           avgt       ≈ 10⁻⁴               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-store-misses                    avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:LLC-stores                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branch-misses                       avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:branches                            avgt        4.005               #/op
+InfrastructureBaselineBenchmark.obj_sink:cycles                              avgt        6.176               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-load-misses                    avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-loads                          avgt       10.005               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-store-misses                   avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:dTLB-stores                         avgt        2.003               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-load-misses                    avgt       ≈ 10⁻⁶               #/op
+InfrastructureBaselineBenchmark.obj_sink:iTLB-loads                          avgt       ≈ 10⁻⁵               #/op
+InfrastructureBaselineBenchmark.obj_sink:instructions                        avgt       21.020               #/op


### PR DESCRIPTION
The idea came to my mind after I read your analysis in regards to black holes and return method types without explicit blackhole. Btw, cool findings, congrats!

Then, I thought to create such a benchmark to assess the "infrastructure" (i.e., especially between different JVMs) and to check if they are equivalent.

A few observations:

- GraalVM EE and OpenJDK Hotspot VM are consistent in terms of baselines for the comparable methods

- OpenJ9 
-- ignores the compiler hints (e.g., DONT_INLINE), we knew it already
-- Blackhole.consume() is more costly -> we probably need to explicitly disable it if we want to compare this VM against HotSpot OpenJDK 17 (similar OpenJDK 11 vs. OpenJDK 17 story), otherwise it will make an unfair comparison ...