### PR TITLE
Add vectorized mandelbrot and sepia filter benchmarks

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/MandelbrotVectorAPIBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/MandelbrotVectorAPIBenchmark.java
@@ -66,7 +66,7 @@ public class MandelbrotVectorAPIBenchmark {
   }
 
   @Benchmark
-  public Object baseline_mandelbrot() {
+  public Object baseline() {
     double threshold = 4;
 
     for (int row = 0; row < size; row++) {
@@ -90,7 +90,7 @@ public class MandelbrotVectorAPIBenchmark {
   }
 
   @Benchmark
-  public Object vectorized_mandelbrot() {
+  public Object vectorized() {
     double threshold = 4;
 
     for (int row = 0;
@@ -141,9 +141,9 @@ public class MandelbrotVectorAPIBenchmark {
 
   @TearDown(Level.Trial)
   public void tearDownInvocation() {
-    double[] seq_res = (double[]) baseline_mandelbrot();
+    double[] seq_res = (double[]) baseline();
     seq_res = Arrays.copyOf(seq_res, seq_res.length);
-    double[] vectorized_res = (double[]) vectorized_mandelbrot();
+    double[] vectorized_res = (double[]) vectorized();
     vectorized_res = Arrays.copyOf(vectorized_res, vectorized_res.length);
 
     if (!Arrays.equals(seq_res, vectorized_res)) {

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/SepiaVectorAPIBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/compiler/SepiaVectorAPIBenchmark.java
@@ -1,0 +1,144 @@
+/**
+ *  JVM Performance Benchmarks
+ *
+ *  Copyright (C) 2019 - 2022 Ionut Balosin
+ *  Website: www.ionutbalosin.com
+ *  Twitter: @ionutbalosin
+ *
+ *  Co-author: Florin Blanaru
+ *  Twitter: @gigiblender
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.compiler;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+/*
+ * Benchmark applying the Sepia filter to a random set of bits using the VectorAPI.
+ *
+ * References:
+ *  - http://cr.openjdk.java.net/~psandoz/conferences/2017-JavaOne/j1-2017-Vector-API-CON4826.pdf
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5, jvmArgsAppend = "--add-modules=jdk.incubator.vector")
+@State(Scope.Benchmark)
+public class SepiaVectorAPIBenchmark {
+
+  private static final VectorSpecies<Float> FLOAT_SPECIES = FloatVector.SPECIES_PREFERRED;
+
+  @Param({"32768", "65536"})
+  private int size;
+
+  private float[] inputR;
+  private float[] inputG;
+  private float[] inputB;
+  private float[] resultR;
+  private float[] resultG;
+  private float[] resultB;
+
+  private static final float r1 = 0.393f,
+      r2 = 0.349f,
+      r3 = 0.272f,
+      g1 = 0.769f,
+      g2 = 0.686f,
+      g3 = 0.534f,
+      b1 = 0.189f,
+      b2 = 0.168f,
+      b3 = 0.131f;
+
+  @Setup
+  public void setup() {
+    inputR = new float[size];
+    inputG = new float[size];
+    inputB = new float[size];
+    resultR = new float[size];
+    resultG = new float[size];
+    resultB = new float[size];
+  }
+
+  @Benchmark
+  public Object baseline() {
+    for (int i = 0; i < size; i++) {
+      resultR[i] = r1 * inputR[i] + g1 * inputG[i] + b1 * inputB[i];
+      resultG[i] = r2 * inputR[i] + g2 * inputG[i] + b2 * inputB[i];
+      resultB[i] = r3 * inputR[i] + g3 * inputG[i] + b3 * inputB[i];
+      if (resultR[i] > 255f) {
+        resultR[i] = 255f;
+      }
+      if (resultG[i] > 255f) {
+        resultG[i] = 255f;
+      }
+      if (resultB[i] > 255f) {
+        resultB[i] = 255f;
+      }
+    }
+    return resultR;
+  }
+
+  @Benchmark
+  public Object vectorized() {
+    for (int i = 0; i < FLOAT_SPECIES.loopBound(size); i += FLOAT_SPECIES.length()) {
+      FloatVector rr1 = FloatVector.broadcast(FLOAT_SPECIES, r1);
+      FloatVector gg1 = FloatVector.broadcast(FLOAT_SPECIES, g1);
+      FloatVector bb1 = FloatVector.broadcast(FLOAT_SPECIES, b1);
+      FloatVector rr2 = FloatVector.broadcast(FLOAT_SPECIES, r2);
+      FloatVector gg2 = FloatVector.broadcast(FLOAT_SPECIES, g2);
+      FloatVector bb2 = FloatVector.broadcast(FLOAT_SPECIES, b2);
+      FloatVector rr3 = FloatVector.broadcast(FLOAT_SPECIES, r3);
+      FloatVector gg3 = FloatVector.broadcast(FLOAT_SPECIES, g3);
+      FloatVector bb3 = FloatVector.broadcast(FLOAT_SPECIES, b3);
+      FloatVector black = FloatVector.broadcast(FLOAT_SPECIES, 255f);
+      FloatVector redVec = FloatVector.fromArray(FLOAT_SPECIES, inputR, i);
+      FloatVector greenVec = FloatVector.fromArray(FLOAT_SPECIES, inputG, i);
+      FloatVector blueVec = FloatVector.fromArray(FLOAT_SPECIES, inputB, i);
+      FloatVector res1 = redVec.mul(rr1).add(greenVec.mul(gg1)).add(blueVec.mul(bb1));
+      FloatVector res2 = redVec.mul(rr2).add(greenVec.mul(gg2)).add(blueVec.mul(bb2));
+      FloatVector res3 = redVec.mul(rr3).add(greenVec.mul(gg3)).add(blueVec.mul(bb3));
+      res1.blend(black, res1.compare(VectorOperators.GT, black)).intoArray(resultR, i);
+      res2.blend(black, res2.compare(VectorOperators.GT, black)).intoArray(resultG, i);
+      res3.blend(black, res3.compare(VectorOperators.GT, black)).intoArray(resultB, i);
+    }
+    return resultR;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDownInvocation() {
+    baseline();
+    float[] seq_r = Arrays.copyOf(resultR, resultB.length);
+    float[] seq_g = Arrays.copyOf(resultG, resultG.length);
+    float[] seq_b = Arrays.copyOf(resultB, resultB.length);
+    vectorized();
+    float[] vec_r = Arrays.copyOf(resultR, resultB.length);
+    float[] vec_g = Arrays.copyOf(resultG, resultG.length);
+    float[] vec_b = Arrays.copyOf(resultB, resultB.length);
+
+    if (!Arrays.equals(seq_r, vec_r)) {
+      throw new AssertionError("The two implementations gave different results");
+    }
+    if (!Arrays.equals(seq_g, vec_g)) {
+      throw new AssertionError("The two implementations gave different results");
+    }
+    if (!Arrays.equals(seq_b, vec_b)) {
+      throw new AssertionError("The two implementations gave different results");
+    }
+  }
+}


### PR DESCRIPTION
Mandelbrot:
OpenJDK 17
```
Benchmark                                           (iterations)  (size)  Mode  Cnt    Score   Error  Units
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            1000     256  avgt    2   19.224          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            1000     512  avgt    2   76.720          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            2000     256  avgt    2   37.746          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            2000     512  avgt    2  151.187          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          1000     256  avgt    2    1.350          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          1000     512  avgt    2    5.034          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          2000     256  avgt    2    2.657          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          2000     512  avgt    2    9.926          ms/op
```


GraalVM 17
```
Benchmark                                           (iterations)  (size)  Mode  Cnt    Score   Error  Units
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            1000     256  avgt    2   19.228          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            1000     512  avgt    2   77.213          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            2000     256  avgt    2   38.046          ms/op
MandelbrotVectorAPIBenchmark.baseline_mandelbrot            2000     512  avgt    2  151.716          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          1000     256  avgt    2   53.324          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          1000     512  avgt    2  197.983          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          2000     256  avgt    2   96.120          ms/op
MandelbrotVectorAPIBenchmark.vectorized_mandelbrot          2000     512  avgt    2  387.561          ms/op
```