### PR TITLE
Add benchmark to sort AVX registers only using other registers

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/SortVectorAPIBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/SortVectorAPIBenchmark.java
@@ -1,0 +1,114 @@
+/**
+ *  JVM Performance Benchmarks
+ *
+ *  Copyright (C) 2019 - 2022 Ionut Balosin
+ *  Website: www.ionutbalosin.com
+ *  Twitter: @ionutbalosin
+ *
+ *  Co-author: Florin Blanaru
+ *  Twitter: @gigiblender
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.micro.compiler;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+/*
+ * This is inspired from "Sorting an AVX512 register" http://0x80.pl/articles/avx512-sort-register.html and from
+ * http://hg.openjdk.java.net/panama/dev/file/a059f2c353cf/test/jdk/jdk/incubator/vector/benchmark/src/main/java/benchmark/jdk/incubator/vector/SortVector.java
+ *
+ * The idea is to sort elements in AVX registers using only intermediate registers.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(
+    value = 5,
+    jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+public class SortVectorAPIBenchmark {
+
+  @Param({"64", "1024", "65536"})
+  int size;
+
+  @Param({"64", "128", "256", "512"})
+  int vector_size;
+
+  VectorSpecies<Integer> species;
+
+  int[] input, result;
+
+  @Setup
+  public void setup() {
+    species = VectorSpecies.of(int.class, VectorShape.forBitSize(vector_size));
+
+    Random random = new Random();
+    input = new int[size];
+    for (int i = 0; i < size; i++) {
+      input[i] = random.nextInt();
+    }
+    result = new int[size];
+  }
+
+  @Benchmark
+  public void sortVector() {
+    VectorSpecies<Integer> species = this.species;
+    var increments = VectorShuffle.iota(species, 0, 1, false).toVector();
+    var result = IntVector.broadcast(species, 0);
+    var index = IntVector.broadcast(species, 0);
+    var increment = IntVector.broadcast(species, 1);
+    for (int i = 0; i < input.length; i += species.length()) {
+      var input = IntVector.fromArray(species, this.input, i);
+      for (int j = 0; j < species.length(); j++) {
+        var element = input.lane(j);
+        var elem_broadcast = IntVector.broadcast(species, element);
+        var lt = input.lt(elem_broadcast).trueCount();
+        var eq = input.eq(elem_broadcast).trueCount();
+        var mask =
+            increments
+                .lt(species.broadcast(lt + eq))
+                .and(increments.lt(species.broadcast(lt)).not());
+        result = result.blend(elem_broadcast, mask);
+        index = index.add(increment);
+      }
+      result.intoArray(this.result, i);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    int[] tmp = new int[species.length()];
+    int[] tmp1 = new int[species.length()];
+
+    for (int i = 0; i < input.length; i += species.length()) {
+      for (int j = 0; j < species.length(); j++) {
+        tmp[j] = result[i + j];
+        tmp1[j] = input[i + j];
+      }
+
+      Arrays.sort(tmp1);
+      if (!Arrays.equals(tmp, tmp1)) {
+        throw new AssertionError(
+            "Arrays are not equal: " + Arrays.toString(tmp) + " != " + Arrays.toString(tmp1));
+      }
+    }
+  }
+}

--- a/jmh_suite_jdk17.json
+++ b/jmh_suite_jdk17.json
@@ -465,6 +465,9 @@
       "name": "SepiaVectorApiBenchmark"
     },
     {
+      "name": "SortVectorApiBenchmark"
+    },
+    {
       "name": "StackSpillingBenchmark"
     },
     {

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
                                 <exclude>**/VectorApiBenchmark.java</exclude>
                                 <exclude>**/MandelbrotVectorApiBenchmark.java</exclude>
                                 <exclude>**/SepiaVectorApiBenchmark.java</exclude>
+                                <exclude>**/SortVectorApiBenchmark.java</exclude>
                             </excludes>
                             <compilerArgs>
                                 <arg>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>


### PR DESCRIPTION
OpenJDK 17: 
```
Benchmark                          (size)  (vector_size)  Mode  Cnt      Score     Error  Units
SortVectorAPIBenchmark.sortVector      64             64  avgt    3      5.718 ±   0.150  us/op
SortVectorAPIBenchmark.sortVector      64            128  avgt    3      2.237 ±   0.027  us/op
SortVectorAPIBenchmark.sortVector      64            256  avgt    3      2.880 ±   0.292  us/op
SortVectorAPIBenchmark.sortVector      64            512  avgt    3     13.415 ±   2.994  us/op
SortVectorAPIBenchmark.sortVector    1024             64  avgt    3     87.467 ±   4.422  us/op
SortVectorAPIBenchmark.sortVector    1024            128  avgt    3     36.059 ±   0.871  us/op
SortVectorAPIBenchmark.sortVector    1024            256  avgt    3     45.043 ±   0.635  us/op
SortVectorAPIBenchmark.sortVector    1024            512  avgt    3    204.778 ±   7.447  us/op
SortVectorAPIBenchmark.sortVector   65536             64  avgt    3   5922.911 ± 279.362  us/op
SortVectorAPIBenchmark.sortVector   65536            128  avgt    3   2307.214 ± 102.641  us/op
SortVectorAPIBenchmark.sortVector   65536            256  avgt    3   2904.540 ±  44.925  us/op
SortVectorAPIBenchmark.sortVector   65536            512  avgt    3  13619.586 ± 153.617  us/op
```

I am not sure yet why using larger vectors does not result in better performance..