### PR TITLE
Image rotate benchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotate.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotate.java
@@ -1,0 +1,76 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.imagerotate;
+
+import java.awt.geom.AffineTransform;
+import java.awt.image.AffineTransformOp;
+import java.awt.image.BufferedImage;
+
+public class ImageRotate {
+
+  public static BufferedImage rotateImage(BufferedImage image, int numQuadrants) {
+    int width0 = image.getWidth();
+    int height0 = image.getHeight();
+    int width1 = width0;
+    int height1 = height0;
+
+    int centerX = width0 / 2;
+    int centerY = height0 / 2;
+
+    if (numQuadrants % 2 == 1) {
+      width1 = height0;
+      height1 = width0;
+    }
+
+    if (numQuadrants % 4 == 1) {
+      if (width0 > height0) {
+        centerX = height0 / 2;
+        centerY = height0 / 2;
+      } else if (height0 > width0) {
+        centerX = width0 / 2;
+        centerY = width0 / 2;
+      }
+      // if height0 == width0, then use default
+    } else if (numQuadrants % 4 == 3) {
+      if (width0 > height0) {
+        centerX = width0 / 2;
+        centerY = width0 / 2;
+      } else if (height0 > width0) {
+        centerX = height0 / 2;
+        centerY = height0 / 2;
+      }
+      // if height0 == width0, then use default
+    }
+
+    final AffineTransform affineTransform = new AffineTransform();
+    affineTransform.setToQuadrantRotation(numQuadrants, centerX, centerY);
+
+    final AffineTransformOp opRotated =
+        new AffineTransformOp(affineTransform, AffineTransformOp.TYPE_BILINEAR);
+
+    BufferedImage transformedImage = new BufferedImage(width1, height1, image.getType());
+    transformedImage = opRotated.filter(image, transformedImage);
+
+    return transformedImage;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotateBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotateBenchmark.java
@@ -60,7 +60,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class ImageRotateBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotateBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/imagerotate/ImageRotateBenchmark.java
@@ -1,0 +1,155 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.imagerotate;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.imagerotate.ImageRotate.rotateImage;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+import javax.imageio.ImageIO;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Rotates a JPEG image clockwise by 90, 180, 270, and 360 degrees (initial position) using the java.awt API.
+ * The initial image to be rotated has a resolution of 6253 x 4169 pixels and a file size of 18.7 MB.
+ *
+ * References:
+ * - http://www.java2s.com/example/java-utility-method/image-rotate/rotateimage-final-file-imagepath-int-numquadrants-49abf.html
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class ImageRotateBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*ImageRotateBenchmark.*"
+
+  private static final String FILE_TYPE = "jpeg";
+  private static final String CURRENT_DIR = System.getProperty("user.dir", ".");
+  private static final String FILE_NAME =
+      CURRENT_DIR + "/benchmarks/src/main/resources/food_banquet.jpg";
+
+  // Each quadrant number corresponds to clockwise degrees, as follows:
+  // 1 - rotate 90 degrees clockwise
+  // 2 - rotate 180 degrees clockwise
+  // 3 - rotate 270 degrees clockwise
+  // 4 - rotate 360 degrees clockwise
+  @Param({"1", "2", "3", "4"})
+  private int quadrant;
+
+  private File outputFile;
+  private BufferedImage inputBufferedImage, outputBufferedImage;
+
+  @Setup(Level.Trial)
+  public void setupTrial() throws IOException {
+    outputFile = File.createTempFile("food_banquet_quadrant_" + quadrant + "_", "." + FILE_TYPE);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDownTrial() {
+    if (outputFile != null) {
+      outputFile.delete();
+    }
+  }
+
+  @Setup(Level.Invocation)
+  public void setupInvocation() throws IOException {
+    try (InputStream inputStream = new BufferedInputStream(new FileInputStream(FILE_NAME))) {
+      inputBufferedImage = ImageIO.read(inputStream);
+    }
+  }
+
+  @TearDown(Level.Invocation)
+  public void tearDownInvocation() throws IOException {
+    try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+      ImageIO.write(outputBufferedImage, FILE_TYPE, outputStream);
+    }
+
+    // make sure the results are valid
+    sanityCheck(inputBufferedImage, outputBufferedImage);
+  }
+
+  @Benchmark
+  public void rotate() {
+    outputBufferedImage = rotateImage(inputBufferedImage, quadrant);
+  }
+
+  /**
+   * Sanity check for the results to avoid wrong benchmarking behaviour
+   *
+   * @param sourceImage - original image
+   * @param destImage - rotated image
+   */
+  private void sanityCheck(BufferedImage sourceImage, BufferedImage destImage) {
+    if (sourceImage.getData().getDataBuffer().getSize()
+        != destImage.getData().getDataBuffer().getSize()) {
+      throw new AssertionError("The rotated image size is not equal to the original image size.");
+    }
+
+    // the image is rotated 90 or 270 degrees clockwise
+    if (quadrant == 1 || quadrant == 3) {
+      if (sourceImage.getHeight() != destImage.getWidth()) {
+        throw new AssertionError(
+            "The image rotated in quadrant " + quadrant + "has a different width.");
+      }
+      if (sourceImage.getWidth() != destImage.getHeight()) {
+        throw new AssertionError(
+            "The image rotated in quadrant " + quadrant + "has a different height.");
+      }
+    }
+
+    // the image is rotated 180 or 360 degrees clockwise
+    if (quadrant == 2 || quadrant == 4) {
+      if (sourceImage.getHeight() != destImage.getHeight()) {
+        throw new AssertionError(
+            "The image rotated in quadrant " + quadrant + "has a different height.");
+      }
+      if (sourceImage.getWidth() != destImage.getWidth()) {
+        throw new AssertionError(
+            "The image rotated in quadrant " + quadrant + "has a different width.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
*** WARNING: JMH support for this VM is experimental. Be extra careful with the produced data.
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                    (quadrant)  Mode  Cnt     Score     Error  Units
ImageRotateBenchmark.rotate           1  avgt    5  1389.354 ± 171.507  ms/op
ImageRotateBenchmark.rotate           2  avgt    5   797.837 ± 199.312  ms/op
ImageRotateBenchmark.rotate           3  avgt    5  1559.476 ± 213.319  ms/op
ImageRotateBenchmark.rotate           4  avgt    5   682.235 ±  28.823  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                    (quadrant)  Mode  Cnt     Score    Error  Units
ImageRotateBenchmark.rotate           1  avgt    5  1275.323 ± 21.746  ms/op
ImageRotateBenchmark.rotate           2  avgt    5   613.736 ±  6.497  ms/op
ImageRotateBenchmark.rotate           3  avgt    5  1397.010 ± 41.441  ms/op
ImageRotateBenchmark.rotate           4  avgt    5   617.375 ± 19.303  ms/op


---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                    (quadrant)  Mode  Cnt     Score    Error  Units
ImageRotateBenchmark.rotate           1  avgt    5  1598.774 ± 94.271  ms/op
ImageRotateBenchmark.rotate           2  avgt    5   615.083 ±  7.952  ms/op
ImageRotateBenchmark.rotate           3  avgt    5  1407.713 ± 57.221  ms/op
ImageRotateBenchmark.rotate           4  avgt    5   617.036 ±  5.806  ms/op
