### PR TITLE
Add NQueensBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/NQueensBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/NQueensBenchmark.java
@@ -1,0 +1,122 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.backtracking.NQueensBacktracking.QUEEN;
+
+import com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.backtracking.NQueensBacktracking;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.simulatedannealing.NQueensSimulatedAnnealing;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * The N-Queens problem is a classic combinatorial problem to place N chess queens on an N×N chessboard in such a way that no two queens can attack each other.
+ * This problem is computationally intensive, and its duration is directly proportional to the chessboard size
+ * (i.e., the larger the chessboard, the more time it takes to compute the solutions).
+ * The benchmark utilizes two alternative approaches to solve the N-Queens problem:
+ * - Backtracking
+ * - Simulated Annealing
+ *
+ * Simulated Annealing is a probabilistic optimization algorithm inspired by the annealing process in metallurgy.
+ * It is used for solving combinatorial optimization problems, where the goal is to find the best solution among a large set of possible solutions.
+ * It starts with an initial solution and iteratively explores neighboring solutions, gradually reducing the "temperature"
+ * (a parameter that controls the probability of accepting worse solutions).
+ *
+ * Backtracking is an algorithmic technique used to systematically explore all possible solutions to a problem by incrementally building
+ * a solution and undoing incorrect choices if they lead to dead-ends. It explores all possible paths in the solution space,
+ * pruning those that violate problem constraints, to find a feasible or optimal solution.
+ *
+ * Note: Simulated Annealing does not guarantee an optimal solution, unlike Backtracking, which guarantees to find the exact solution if it exists.
+ *
+ * The performance of Simulated Annealing versus Backtracking can vary significantly based on the choice of parameters, cooling schedule, N-size, etc. Example:
+ * - for a smaller N (e.g., N=8; i.e., a typical 8x8 chessboard size), Backtracking is capable of finding all possible solutions relatively quickly.
+ * - for a larger N (e.g., N=64, i.e., 64x64 chessboard size), the search space becomes astronomically large, making it less practical for Backtracking to explore all configurations.
+ * In such cases, Simulated Annealing may become more practical, as it can efficiently explore the search space but without guaranteeing an optimal solution.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class NQueensBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*NQueensBenchmark.*"
+
+  @Param({"16", "64"})
+  private int n;
+
+  // the current (starting) row to place a queen on the chessboard
+  private int startingRow;
+  private final Random random = new Random(16384);
+
+  @Setup()
+  public void setup() {
+    startingRow = random.nextInt(n);
+
+    // make sure the results are equivalent before any further benchmarking
+    sanityCheck(NQueensBacktracking.placeNQueens(n, startingRow));
+    sanityCheck(NQueensSimulatedAnnealing.placeNQueens(n, startingRow));
+  }
+
+  @Benchmark
+  public byte[][] backtracking() {
+    return NQueensBacktracking.placeNQueens(n, startingRow);
+  }
+
+  @Benchmark
+  public byte[][] simulated_annealing() {
+    return NQueensSimulatedAnnealing.placeNQueens(n, startingRow);
+  }
+
+  /**
+   * Sanity check for the results to avoid wrong benchmarks comparisons
+   *
+   * @param board - chess board representing the N Queens properly positioned
+   */
+  private void sanityCheck(byte[][] board) {
+    int nQueens = 0;
+    for (byte[] row : board) {
+      for (byte position : row) {
+        if (position == QUEEN) {
+          nQueens++;
+        }
+      }
+    }
+
+    if (nQueens != n) {
+      throw new AssertionError("The number of placed queens is different from the expected value.");
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/backtracking/NQueensBacktracking.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/backtracking/NQueensBacktracking.java
@@ -1,0 +1,80 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.backtracking;
+
+import java.util.Arrays;
+
+public class NQueensBacktracking {
+
+  public static final byte QUEEN = 1;
+  public static final byte EMPTY = 0;
+
+  public static byte[][] placeNQueens(int n, int row) {
+    final byte[][] board = new byte[n][n];
+
+    for (byte[] boardRow : board) {
+      Arrays.fill(boardRow, EMPTY);
+    }
+
+    backtrack(board, n, row, 0);
+    return board;
+  }
+
+  private static boolean backtrack(byte[][] board, int n, int row, int queensPlaced) {
+    if (queensPlaced == n) {
+      return true;
+    }
+
+    if (row == n) {
+      row = 0; // Reset the row to the beginning if we reach the end
+    }
+
+    for (int col = 0; col < n; col++) {
+      if (isValidPlacement(board, row, col, n)) {
+        board[row][col] = QUEEN;
+        if (backtrack(board, n, row + 1, queensPlaced + 1)) {
+          return true;
+        }
+        board[row][col] = EMPTY;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isValidPlacement(byte[][] board, int row, int col, int n) {
+    for (int i = 0; i < row; i++) {
+      if (board[i][col] == QUEEN) {
+        return false;
+      }
+      int leftDiagonal = col - (row - i);
+      int rightDiagonal = col + (row - i);
+      if (leftDiagonal >= 0 && board[i][leftDiagonal] == QUEEN) {
+        return false;
+      }
+      if (rightDiagonal < n && board[i][rightDiagonal] == QUEEN) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/simulatedannealing/NQueensSimulatedAnnealing.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/nqueens/simulatedannealing/NQueensSimulatedAnnealing.java
@@ -1,0 +1,117 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.simulatedannealing;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.backtracking.NQueensBacktracking.EMPTY;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.nqueens.backtracking.NQueensBacktracking.QUEEN;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class NQueensSimulatedAnnealing {
+
+  private static final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+  public static byte[][] placeNQueens(int n, int row) {
+    int[] queenColumns = generateRandomSolution(n);
+    double temperature = 10000.0;
+    double coolingRate = 0.003;
+
+    // Starting from the specified row
+    if (row >= 0 && row < n) {
+      queenColumns[row] = random.nextInt(n); // Randomly place a queen in the starting row
+    }
+
+    while (temperature > 1.0) {
+      int[] nextSolution = generateNeighborSolution(queenColumns);
+      int currentEnergy = calculateEnergy(queenColumns);
+      int nextEnergy = calculateEnergy(nextSolution);
+
+      double acceptanceProbability =
+          calculateAcceptanceProbability(currentEnergy, nextEnergy, temperature);
+
+      if (acceptanceProbability > Math.random()) {
+        queenColumns = nextSolution;
+      }
+
+      temperature *= (1.0 - coolingRate);
+    }
+
+    return constructBoard(queenColumns);
+  }
+
+  private static byte[][] constructBoard(int[] queenColumns) {
+    int n = queenColumns.length;
+    byte[][] board = new byte[n][n];
+
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < n; j++) {
+        board[i][j] = queenColumns[i] == j ? QUEEN : EMPTY;
+      }
+    }
+
+    return board;
+  }
+
+  private static int[] generateRandomSolution(int n) {
+    int[] solution = new int[n];
+
+    for (int i = 0; i < n; i++) {
+      solution[i] = random.nextInt(n); // Place each queen randomly in a column of its row
+    }
+
+    return solution;
+  }
+
+  private static int[] generateNeighborSolution(int[] solution) {
+    int n = solution.length;
+    int[] neighborSolution = solution.clone();
+
+    int row = random.nextInt(n); // Select a random row to move a queen
+    neighborSolution[row] = random.nextInt(n); // Move the queen to a random column in its row
+
+    return neighborSolution;
+  }
+
+  private static int calculateEnergy(int[] solution) {
+    int n = solution.length;
+    int energy = 0;
+
+    for (int i = 0; i < n; i++) {
+      for (int j = i + 1; j < n; j++) {
+        if (solution[i] == solution[j] || Math.abs(solution[i] - solution[j]) == j - i) {
+          energy++; // Queens attacking each other
+        }
+      }
+    }
+
+    return energy;
+  }
+
+  private static double calculateAcceptanceProbability(
+      int currentEnergy, int nextEnergy, double temperature) {
+    if (nextEnergy < currentEnergy) {
+      return 1.0; // Accept better solutions
+    }
+    return Math.exp((currentEnergy - nextEnergy) / temperature);
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                             (n)  Mode  Cnt    Score    Error  Units
NQueensBenchmark.backtracking          16  avgt    5    0.028 ±  0.001  ms/op
NQueensBenchmark.backtracking          64  avgt    5  647.679 ±  7.562  ms/op
NQueensBenchmark.simulated_annealing   16  avgt    5    6.344 ±  0.014  ms/op
NQueensBenchmark.simulated_annealing   64  avgt    5   51.289 ± 17.303  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                             (n)  Mode  Cnt    Score    Error  Units
NQueensBenchmark.backtracking          16  avgt    5    0.024 ±  0.001  ms/op
NQueensBenchmark.backtracking          64  avgt    5  585.411 ±  3.050  ms/op
NQueensBenchmark.simulated_annealing   16  avgt    5    6.889 ±  2.450  ms/op
NQueensBenchmark.simulated_annealing   64  avgt    5   43.674 ±  0.529  ms/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                             (n)  Mode  Cnt    Score    Error  Units
NQueensBenchmark.backtracking          16  avgt    5    0.022 ±  0.001  ms/op
NQueensBenchmark.backtracking          64  avgt    5  501.247 ±  3.147  ms/op
NQueensBenchmark.simulated_annealing   16  avgt    5    4.462 ±  0.024  ms/op
NQueensBenchmark.simulated_annealing   64  avgt    5   16.201 ±  0.095  ms/op