### PR TITLE
Publication statistics benchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationGenerator.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics;
+
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Author;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Publication;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PublicationGenerator {
+
+  private static final int PUBLICATIONS = 100_000;
+  public static final int FIRST_YEAR = 1900;
+  public static final int LAST_YEAR = 2000;
+  private static final int PUBLICATION_TYPES = 100;
+  private static final int AUTHORS = 1_000;
+  private static final int MAX_AUTHORS_PER_PUBLICATION = 9;
+  private static final Random random = new Random(16384);
+
+  public static Set<Publication> generatePublications() {
+    final Set<Publication> publication = new HashSet<>(PUBLICATIONS);
+
+    for (int i = 1; i <= PUBLICATIONS; i++) {
+      int year = random.nextInt(FIRST_YEAR, LAST_YEAR + 1);
+      String title = "Title_" + i;
+      String type = "Type_" + random.nextInt(PUBLICATION_TYPES);
+      List<Author> authors = generateAuthors();
+      publication.add(new Publication(year, title, type, authors));
+    }
+
+    return publication;
+  }
+
+  private static List<Author> generateAuthors() {
+    return IntStream.range(1, random.nextInt(MAX_AUTHORS_PER_PUBLICATION) + 2)
+        .mapToObj(counter -> "Author_" + random.nextInt(AUTHORS))
+        .map(Author::of)
+        .collect(Collectors.toList());
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
@@ -1,0 +1,277 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationGenerator.FIRST_YEAR;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors.crossProductOrdered;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors.groupingByAndCounting;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors.groupingBySelfAndCounting;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors.maxByValue;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors.removeEmptyStreams;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.collectingAndThen;
+
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Author;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Publication;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PublicationStatistics {
+
+  // Returns the number of publications for each year
+  public static Map<Integer, Long> numberOfPublicationsPerYear(Set<Publication> publications) {
+    final Map<Integer, Long> result =
+        publications.stream().collect(groupingByAndCounting(Publication::getYear));
+
+    return result;
+  }
+
+  // Returns one (i.e., the first) year with the most publications
+  public static Map.Entry<Integer, Long> yearWithTheMostPublications(
+      Set<Publication> publications) {
+    final Map.Entry<Integer, Long> result =
+        publications.stream()
+            .collect(collectingAndThen(groupingByAndCounting(Publication::getYear), maxByValue()));
+
+    return result;
+  }
+
+  // Returns all years with the most publications (in case there are many)
+  public static Map.Entry<Long, List<Integer>> yearsWithTheMostPublications(
+      Set<Publication> publications) {
+    final Map<Integer, Long> numberOfPublicationsPerYear =
+        numberOfPublicationsPerYear(publications);
+    final Map.Entry<Long, List<Integer>> result =
+        numberOfPublicationsPerYear.entrySet().stream()
+            .collect(Collectors.groupingBy(entry -> entry.getValue()))
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    entry -> entry.getKey(),
+                    entry ->
+                        entry.getValue().stream()
+                            .map(e -> e.getKey())
+                            .collect(Collectors.toList())))
+            .entrySet()
+            .stream()
+            .max(Map.Entry.comparingByKey())
+            .get();
+
+    return result;
+  }
+
+  // Returns the number of publications for each author
+  public static Map<Author, Long> numberOfPublicationsPerAuthor(Set<Publication> publications) {
+    final Map<Author, Long> result =
+        publications.stream()
+            .flatMap(publication -> publication.getAuthors().stream())
+            .collect(groupingBySelfAndCounting());
+
+    return result;
+  }
+
+  // Returns the author that published the most publications
+  public static Map.Entry<Author, Long> authorWithTheMostPublications(
+      Set<Publication> publications) {
+    final Map.Entry<Author, Long> result =
+        publications.stream()
+            .flatMap(publication -> publication.getAuthors().stream())
+            .collect(Collectors.collectingAndThen(groupingBySelfAndCounting(), maxByValue()));
+
+    return result;
+  }
+
+  // Returns the authors who never collaborated with the same author twice
+  public static Set<Author> authorsWithNoDuplicateCollaborations(Set<Publication> publications) {
+    return publications.stream()
+        .flatMap(publication -> publication.getAuthors().stream())
+        .collect(Collectors.groupingBy(author -> author.getName(), Collectors.toSet()))
+        .values()
+        .stream()
+        .filter(
+            collaborations ->
+                collaborations.size()
+                    == collaborations.stream().map(Author::getName).distinct().count())
+        .flatMap(Set::stream)
+        .collect(Collectors.toSet());
+  }
+
+  // Returns the first publication year
+  public static int firstPublicationYear(Set<Publication> publications) {
+    final int result =
+        publications.stream()
+            .filter(publication -> publication.getYear() >= FIRST_YEAR)
+            .map(Publication::getYear)
+            .collect(Collectors.minBy(Comparator.naturalOrder()))
+            .get();
+
+    return result;
+  }
+
+  // Returns the last publication year
+  public static int lastPublicationYear(Set<Publication> publications) {
+    final int result =
+        publications.stream()
+            .filter(publication -> publication.getYear() >= FIRST_YEAR)
+            .map(Publication::getYear)
+            .collect(Collectors.maxBy(Comparator.naturalOrder()))
+            .get();
+
+    return result;
+  }
+
+  // Returns some statistics for publications' years
+  public static IntSummaryStatistics publicationsYearsStatistics(Set<Publication> publications) {
+    final IntSummaryStatistics result =
+        publications.stream()
+            .filter(publication -> publication.getYear() >= FIRST_YEAR)
+            .collect(Collectors.summarizingInt(Publication::getYear));
+
+    return result;
+  }
+
+  // Returns the publication with the most authors
+  public static Publication publicationWithTheMostAuthors(Set<Publication> publications) {
+    final Publication result =
+        publications.stream()
+            .filter(publication -> publication.getYear() >= FIRST_YEAR)
+            .max(Comparator.comparing(publication -> publication.getAuthors().size()))
+            .get();
+
+    return result;
+  }
+
+  // Returns the publication with the most authors for each year
+  public static Map<Integer, Publication> publicationsWithTheMostAuthorsPerYear(
+      Set<Publication> publications) {
+    final Collector<Publication, ?, Stream<Publication>> publicationsWithTheMostAuthors =
+        Collectors.filtering(
+            publication -> publication.getYear() >= FIRST_YEAR,
+            Collectors.collectingAndThen(
+                Collectors.maxBy(
+                    Comparator.comparing(publication -> publication.getAuthors().size())),
+                Optional::stream));
+    final Function<Map.Entry<Integer, Stream<Publication>>, Stream<Map.Entry<Integer, Publication>>>
+        emptyStreamsRemover =
+            entry -> entry.getValue().map(value -> Map.entry(entry.getKey(), value));
+    final Function<Map<Integer, Stream<Publication>>, Map<Integer, Publication>>
+        emptyStreamValuesRemover =
+            map ->
+                map.entrySet().stream()
+                    .collect(
+                        Collectors.flatMapping(
+                            emptyStreamsRemover, CustomCollectors.toNaturalMap()));
+    final Collector<Publication, ?, Map<Integer, Publication>> finalCollector =
+        Collectors.collectingAndThen(
+            Collectors.groupingBy(Publication::getYear, publicationsWithTheMostAuthors),
+            emptyStreamValuesRemover);
+    final Map<Integer, Publication> result = publications.stream().collect(finalCollector);
+
+    return result;
+  }
+
+  // Returns all authors' publications
+  public static Map<Author, List<Publication>> publicationsPerAuthor(
+      Set<Publication> publications) {
+    final Map<Publication, List<Author>> authorsPerPublications =
+        publications.stream()
+            .collect(
+                Collectors.toMap(
+                    publication -> publication, publication -> publication.getAuthors()));
+    final Function<Map<Publication, List<Author>>, Map<Author, List<Publication>>> invertMultiMap =
+        CustomCollectors.invertMultiMap();
+    final Map<Author, List<Publication>> result = invertMultiMap.apply(authorsPerPublications);
+
+    return result;
+  }
+
+  // Returns the pair of authors that published the most publications together
+  public static Map.Entry<Map.Entry<Author, Author>, Long> mostProlificPairOfAuthors(
+      Set<Publication> publications) {
+    final Function<Stream<Author>, Stream<Map.Entry<Author, Author>>> function =
+        authorStream -> crossProductOrdered(authorStream, comparing(Author::getName));
+    final Collector<Publication, ?, Map.Entry<Map.Entry<Author, Author>, Long>>
+        mostProlificAuthorsCollector =
+            Collectors.flatMapping(
+                publication -> function.apply(publication.getAuthors().stream()),
+                Collectors.collectingAndThen(
+                    CustomCollectors.groupingBySelfAndCounting(), CustomCollectors.maxByValue()));
+    final Map.Entry<Map.Entry<Author, Author>, Long> result =
+        publications.stream().collect(mostProlificAuthorsCollector);
+
+    return result;
+  }
+
+  // Returns the pair of authors that published the most publications together for each year
+  public static Map<Integer, Map.Entry<Map.Entry<Author, Author>, Long>>
+      mostProlificPairOfAuthorsPerYear(Set<Publication> publications) {
+    final Map<Integer, Map.Entry<Map.Entry<Author, Author>, Long>> result =
+        publications.stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.groupingBy(
+                        Publication::getYear,
+                        CustomCollectors.mostProlific(
+                            publication -> publication.getAuthors().stream(),
+                            comparing(Author::getName))),
+                    removeEmptyStreams()));
+
+    return result;
+  }
+
+  // Returns a co-author network
+  public static Map<Author, List<Author>> coAuthorNetwork(Set<Publication> publications) {
+    return publications.stream()
+        .flatMap(
+            publication ->
+                publication.getAuthors().stream()
+                    .map(
+                        author ->
+                            new AbstractMap.SimpleEntry<>(
+                                author,
+                                publication.getAuthors().stream()
+                                    .filter(source -> !source.equals(author))
+                                    .collect(Collectors.toList()))))
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (coAuthors1, coAuthors2) -> {
+                  List<Author> combined = new ArrayList<>(coAuthors1);
+                  combined.addAll(coAuthors2);
+                  return combined;
+                }));
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
@@ -34,8 +34,6 @@ import static java.util.stream.Collectors.collectingAndThen;
 import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Author;
 import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Publication;
 import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util.CustomCollectors;
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.IntSummaryStatistics;
 import java.util.List;
@@ -249,29 +247,5 @@ public class PublicationStatistics {
                     removeEmptyStreams()));
 
     return result;
-  }
-
-  // Returns a co-author network
-  public static Map<Author, List<Author>> coAuthorNetwork(Set<Publication> publications) {
-    return publications.stream()
-        .flatMap(
-            publication ->
-                publication.getAuthors().stream()
-                    .map(
-                        author ->
-                            new AbstractMap.SimpleEntry<>(
-                                author,
-                                publication.getAuthors().stream()
-                                    .filter(source -> !source.equals(author))
-                                    .collect(Collectors.toList()))))
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                (coAuthors1, coAuthors2) -> {
-                  List<Author> combined = new ArrayList<>(coAuthors1);
-                  combined.addAll(coAuthors2);
-                  return combined;
-                }));
   }
 }

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatistics.java
@@ -100,7 +100,7 @@ public class PublicationStatistics {
     return result;
   }
 
-  // Returns the author that published the most publications
+  // Returns the author who published the most articles
   public static Map.Entry<Author, Long> authorWithTheMostPublications(
       Set<Publication> publications) {
     final Map.Entry<Author, Long> result =
@@ -111,7 +111,7 @@ public class PublicationStatistics {
     return result;
   }
 
-  // Returns the authors who never collaborated with the same author twice
+  // Returns the authors who have never collaborated with the same publication twice
   public static Set<Author> authorsWithNoDuplicateCollaborations(Set<Publication> publications) {
     return publications.stream()
         .flatMap(publication -> publication.getAuthors().stream())
@@ -126,8 +126,8 @@ public class PublicationStatistics {
         .collect(Collectors.toSet());
   }
 
-  // Returns the first publication year
-  public static int firstPublicationYear(Set<Publication> publications) {
+  // Returns the year of the first publication
+  public static int yearOfTheFirstPublication(Set<Publication> publications) {
     final int result =
         publications.stream()
             .filter(publication -> publication.getYear() >= FIRST_YEAR)
@@ -138,8 +138,8 @@ public class PublicationStatistics {
     return result;
   }
 
-  // Returns the last publication year
-  public static int lastPublicationYear(Set<Publication> publications) {
+  // Returns the year of the last publication
+  public static int yearOfTheLastPublication(Set<Publication> publications) {
     final int result =
         publications.stream()
             .filter(publication -> publication.getYear() >= FIRST_YEAR)
@@ -215,7 +215,7 @@ public class PublicationStatistics {
     return result;
   }
 
-  // Returns the pair of authors that published the most publications together
+  // Returns the pair of authors who published the most publications together
   public static Map.Entry<Map.Entry<Author, Author>, Long> mostProlificPairOfAuthors(
       Set<Publication> publications) {
     final Function<Stream<Author>, Stream<Map.Entry<Author, Author>>> function =
@@ -232,7 +232,7 @@ public class PublicationStatistics {
     return result;
   }
 
-  // Returns the pair of authors that published the most publications together for each year
+  // Returns the pair of authors who published the most publications together for each year
   public static Map<Integer, Map.Entry<Map.Entry<Author, Author>, Long>>
       mostProlificPairOfAuthorsPerYear(Set<Publication> publications) {
     final Map<Integer, Map.Entry<Map.Entry<Author, Author>, Long>> result =

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
@@ -24,8 +24,6 @@ package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics;
 
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorWithTheMostPublications;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorsWithNoDuplicateCollaborations;
-import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.firstPublicationYear;
-import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.lastPublicationYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.mostProlificPairOfAuthors;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.mostProlificPairOfAuthorsPerYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.numberOfPublicationsPerAuthor;
@@ -34,6 +32,8 @@ import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstati
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsPerAuthor;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsWithTheMostAuthorsPerYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsYearsStatistics;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearOfTheFirstPublication;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearOfTheLastPublication;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearWithTheMostPublications;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearsWithTheMostPublications;
 
@@ -56,6 +56,22 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 /*
+ * This benchmark extensively uses the Collectors/Streams API to perform a bunch of operations on a list of publications and their authors
+ * producing different final results (i.e., statistics), including:
+ * - the year(s) with the most publications
+ * - the number of publications for each author
+ * - the author who published the most articles
+ * - the authors who have never collaborated with the same publication twice
+ * - the year of the first publication
+ * - the year of the last publication
+ * - the publication with the most authors (for each year).
+ * - the pair of authors who published the most publications together (for each year).
+ *
+ * The list of publications is randomly generated at the beginning of the benchmark and consists of 100,000 items,
+ * with each publication having a maximum of 9 authors. All of these publications are generated between the years 1900 and 2000,
+ * and in total, they have around 100 distinct types.
+ * The total number of authors is 1,000 (which means, on average, every author could potentially write around 100 articles).
+ *
  * References:
  * - code examples by Jose Paumard (Twitter: @JosePaumard)
  * - https://github.com/JosePaumard/devoxx-be-2017
@@ -89,12 +105,12 @@ public class PublicationStatisticsBenchmark {
 
   @Benchmark
   public int first_publication_year() {
-    return firstPublicationYear(publications);
+    return yearOfTheFirstPublication(publications);
   }
 
   @Benchmark
   public int last_publication_year() {
-    return lastPublicationYear(publications);
+    return yearOfTheLastPublication(publications);
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
@@ -1,0 +1,143 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorWithTheMostPublications;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorsWithNoDuplicateCollaborations;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.coAuthorNetwork;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.firstPublicationYear;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.lastPublicationYear;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.numberOfPublicationsPerAuthor;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.numberOfPublicationsPerYear;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationWithTheMostAuthors;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsPerAuthor;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsWithTheMostAuthorsPerYear;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationsYearsStatistics;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearWithTheMostPublications;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.yearsWithTheMostPublications;
+
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Author;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model.Publication;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * References:
+ * - code examples by Jose Paumard (Twitter: @JosePaumard)
+ * - https://github.com/JosePaumard/devoxx-be-2017
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class PublicationStatisticsBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*PublicationStatisticsBenchmark.*"
+
+  private static Set<Publication> publications;
+
+  @Setup()
+  public void setupTrial() {
+    publications = PublicationGenerator.generatePublications();
+  }
+
+  @Benchmark
+  public Map.Entry<Integer, Long> year_with_the_most_publications() {
+    return yearWithTheMostPublications(publications);
+  }
+
+  @Benchmark
+  public Map.Entry<Long, List<Integer>> years_with_the_most_publications() {
+    return yearsWithTheMostPublications(publications);
+  }
+
+  @Benchmark
+  public int first_publication_year() {
+    return firstPublicationYear(publications);
+  }
+
+  @Benchmark
+  public int last_publication_year() {
+    return lastPublicationYear(publications);
+  }
+
+  @Benchmark
+  public Map.Entry<Author, Long> author_with_the_most_publications() {
+    return authorWithTheMostPublications(publications);
+  }
+
+  @Benchmark
+  public Set<Author> authors_with_no_duplicate_collaborations() {
+    return authorsWithNoDuplicateCollaborations(publications);
+  }
+
+  @Benchmark
+  public Map<Author, List<Publication>> publications_per_author() {
+    return publicationsPerAuthor(publications);
+  }
+
+  @Benchmark
+  public Map<Integer, Long> number_of_publications_per_year() {
+    return numberOfPublicationsPerYear(publications);
+  }
+
+  @Benchmark
+  public Map<Author, Long> number_of_publications_per_author() {
+    return numberOfPublicationsPerAuthor(publications);
+  }
+
+  @Benchmark
+  public Publication publication_with_the_most_authors() {
+    return publicationWithTheMostAuthors(publications);
+  }
+
+  @Benchmark
+  public Map<Integer, Publication> publications_with_the_most_authors_per_year() {
+    return publicationsWithTheMostAuthorsPerYear(publications);
+  }
+
+  @Benchmark
+  public IntSummaryStatistics publications_years_statistics() {
+    return publicationsYearsStatistics(publications);
+  }
+
+  @Benchmark
+  public Map<Author, List<Author>> co_author_network() {
+    return coAuthorNetwork(publications);
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/PublicationStatisticsBenchmark.java
@@ -24,9 +24,10 @@ package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics;
 
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorWithTheMostPublications;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.authorsWithNoDuplicateCollaborations;
-import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.coAuthorNetwork;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.firstPublicationYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.lastPublicationYear;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.mostProlificPairOfAuthors;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.mostProlificPairOfAuthorsPerYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.numberOfPublicationsPerAuthor;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.numberOfPublicationsPerYear;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.PublicationStatistics.publicationWithTheMostAuthors;
@@ -137,7 +138,13 @@ public class PublicationStatisticsBenchmark {
   }
 
   @Benchmark
-  public Map<Author, List<Author>> co_author_network() {
-    return coAuthorNetwork(publications);
+  public Map.Entry<Map.Entry<Author, Author>, Long> most_prolific_pair_of_authors() {
+    return mostProlificPairOfAuthors(publications);
+  }
+
+  @Benchmark
+  public Map<Integer, Map.Entry<Map.Entry<Author, Author>, Long>>
+      most_prolific_pair_of_authors_per_year() {
+    return mostProlificPairOfAuthorsPerYear(publications);
   }
 }

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/model/Author.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/model/Author.java
@@ -1,0 +1,59 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model;
+
+import java.util.Objects;
+
+public class Author {
+
+  private final String name;
+
+  public static Author of(String authorName) {
+    return new Author(authorName);
+  }
+
+  private Author(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Author author)) return false;
+    return Objects.equals(name, author.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    return "Author{" + "name='" + name + '\'' + '}';
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/model/Publication.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/model/Publication.java
@@ -1,0 +1,83 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public class Publication {
+
+  private int year;
+  private final String title;
+  private final String type;
+  private final List<Author> authors;
+
+  public Publication(int year, String title, String type, List<Author> authors) {
+    this.year = year;
+    this.title = title;
+    this.type = type;
+    this.authors = authors;
+  }
+
+  public int getYear() {
+    return year;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public List<Author> getAuthors() {
+    return authors;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Publication article)) return false;
+    return year == article.year
+        && Objects.equals(title, article.title)
+        && Objects.equals(type, article.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(year, title, type);
+  }
+
+  @Override
+  public String toString() {
+    return "Publication{"
+        + "year="
+        + year
+        + ", title='"
+        + title
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", authors="
+        + authors
+        + '}';
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/util/CustomCollectors.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/util/CustomCollectors.java
@@ -1,0 +1,102 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class CustomCollectors {
+
+  public static <T, K> Collector<T, ?, Map<K, Long>> groupingByAndCounting(
+      Function<T, K> classifier) {
+    return Collectors.groupingBy(classifier, Collectors.counting());
+  }
+
+  public static <K, V extends Comparable<? super V>>
+      Function<Map<K, V>, Map.Entry<K, V>> maxByValue() {
+    return maxBy(Map.Entry.<K, V>comparingByValue());
+  }
+
+  public static <K, V extends Comparable<? super V>> Function<Map<K, V>, Map.Entry<K, V>> maxBy(
+      Comparator<Map.Entry<K, V>> comparator) {
+    return map -> map.entrySet().stream().max(comparator).get();
+  }
+
+  public static <T> Collector<T, ?, Map<T, Long>> groupingBySelfAndCounting() {
+    return groupingByAndCounting(Function.identity());
+  }
+
+  public static <K, V> Collector<Map.Entry<K, V>, ?, Map<K, V>> toNaturalMap() {
+    return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
+  }
+
+  public static <K, V> Function<Map<K, Stream<V>>, Map<K, V>> removeEmptyStreams() {
+    return map ->
+        map.entrySet().stream()
+            .flatMap(entry -> entry.getValue().map(e -> Map.entry(entry.getKey(), e)))
+            .collect(toNaturalMap());
+  }
+
+  public static <T, V> Collector<T, ?, Stream<Map.Entry<Map.Entry<V, V>, Long>>> mostProlific(
+      Function<T, Stream<V>> streamMapper, Comparator<V> comparator) {
+
+    return Collectors.flatMapping(
+        article -> crossProductOrdered(streamMapper.apply(article), comparator),
+        Collectors.collectingAndThen(
+            groupingBySelfAndCounting(),
+            map ->
+                map.entrySet().stream()
+                    .max(Map.Entry.<Map.Entry<V, V>, Long>comparingByValue())
+                    .stream()));
+  }
+
+  public static <E> Stream<Map.Entry<E, E>> crossProductOrdered(
+      Stream<E> stream, Comparator<E> comparator) {
+    Objects.requireNonNull(stream);
+    Objects.requireNonNull(comparator);
+
+    OrderedSpliterator<E> spliterator =
+        OrderedSpliterator.ordered(stream.spliterator(), comparator);
+
+    return StreamSupport.stream(spliterator, stream.isParallel()).onClose(stream::close);
+  }
+
+  public static <K, V> Function<Map<K, List<V>>, Map<V, List<K>>> invertMultiMap() {
+    return map ->
+        map.entrySet().stream()
+            .collect(
+                Collectors.flatMapping(
+                    entry ->
+                        entry.getValue().stream().map(value -> Map.entry(entry.getKey(), value)),
+                    Collectors.groupingBy(
+                        Map.Entry::getValue,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toList()))));
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/util/OrderedSpliterator.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/publicationstatistics/util/OrderedSpliterator.java
@@ -1,0 +1,171 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.publicationstatistics.util;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class OrderedSpliterator<E> implements Spliterator<Map.Entry<E, E>> {
+
+  private Spliterator<E> spliterator;
+  private List<E> buffer = new ArrayList<>();
+  private UnaryOperator<Long> estimateSize;
+
+  private final Function<Consumer<? super Map.Entry<E, E>>, BiConsumer<E, E>> function;
+  private boolean hasMore = true;
+  private Iterator<Map.Entry<E, E>> iterator;
+  private boolean consumingIterator = false;
+
+  public static <E> OrderedSpliterator<E> ordered(
+      Spliterator<E> spliterator, Comparator<E> comparator) {
+    return new OrderedSpliterator<>(
+        spliterator,
+        a ->
+            (e1, e2) -> {
+              int compare = comparator.compare(e2, e1);
+              if (compare > 0) {
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e1, e2));
+              } else if (compare < 0) {
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e2, e1));
+              }
+            },
+        estimateSize ->
+            (estimateSize == Long.MAX_VALUE)
+                    || (estimateSize * (estimateSize - 1) / 2 < estimateSize)
+                ? Long.MAX_VALUE
+                : estimateSize * (estimateSize - 1) / 2);
+  }
+
+  public static <E> OrderedSpliterator<E> noDoubles(Spliterator<E> spliterator) {
+    return new OrderedSpliterator<>(
+        spliterator,
+        a ->
+            (e1, e2) -> {
+              if (!e1.equals(e2)) {
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e1, e2));
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e2, e1));
+              }
+            },
+        estimateSize ->
+            (estimateSize == Long.MAX_VALUE) || (estimateSize * (estimateSize - 1) < estimateSize)
+                ? Long.MAX_VALUE
+                : (estimateSize * (estimateSize - 1)));
+  }
+
+  public static <E> OrderedSpliterator<E> of(Spliterator<E> spliterator) {
+    return new OrderedSpliterator<>(
+        spliterator,
+        a ->
+            (e1, e2) -> {
+              if (e1.equals(e2)) {
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e1, e2));
+              } else {
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e1, e2));
+                a.accept(new AbstractMap.SimpleImmutableEntry<>(e2, e1));
+              }
+            },
+        estimateSize ->
+            (estimateSize == Long.MAX_VALUE) || (estimateSize * estimateSize < estimateSize)
+                ? Long.MAX_VALUE
+                : estimateSize * estimateSize);
+  }
+
+  private OrderedSpliterator(
+      Spliterator<E> spliterator,
+      Function<Consumer<? super Map.Entry<E, E>>, BiConsumer<E, E>> function,
+      UnaryOperator<Long> estimateSize) {
+
+    this.spliterator = spliterator;
+    this.function = function;
+    this.estimateSize = estimateSize;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super Map.Entry<E, E>> action) {
+
+    Stream.Builder<Map.Entry<E, E>> builder = Stream.builder();
+    if (consumingIterator) {
+      if (iterator.hasNext()) {
+        action.accept(iterator.next());
+        return true;
+      } else {
+        consumingIterator = false;
+      }
+    }
+    if (hasMore) {
+      fillBuilder(builder);
+      consumingIterator = true;
+    }
+
+    List<Map.Entry<E, E>> entryList = builder.build().collect(Collectors.toList());
+    while (entryList.isEmpty() && hasMore) {
+      builder = Stream.builder();
+      fillBuilder(builder);
+      entryList = builder.build().collect(Collectors.toList());
+    }
+    iterator = entryList.iterator();
+    if (iterator.hasNext()) {
+      action.accept(iterator.next());
+      return true;
+    }
+
+    return false;
+  }
+
+  private void fillBuilder(Stream.Builder<Map.Entry<E, E>> builder) {
+    BiConsumer<E, E> biConsumer = function.apply(builder::add);
+    hasMore =
+        spliterator.tryAdvance(
+            e1 -> {
+              buffer.add(e1);
+              buffer.forEach(e2 -> biConsumer.accept(e1, e2));
+            });
+  }
+
+  @Override
+  public Spliterator<Map.Entry<E, E>> trySplit() {
+    return null;
+  }
+
+  @Override
+  public long estimateSize() {
+    long estimateSize = this.spliterator.estimateSize();
+    return this.estimateSize.apply(estimateSize);
+  }
+
+  @Override
+  public int characteristics() {
+    return this.spliterator.characteristics() & ~Spliterator.SORTED;
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                                                                   Mode  Cnt      Score      Error  Units
PublicationStatisticsBenchmark.author_with_the_most_publications            avgt    5    109.161 ±   39.574  ms/op
PublicationStatisticsBenchmark.authors_with_no_duplicate_collaborations     avgt    5    133.532 ±    2.785  ms/op
PublicationStatisticsBenchmark.first_publication_year                       avgt    5     13.955 ±    0.173  ms/op
PublicationStatisticsBenchmark.last_publication_year                        avgt    5     14.146 ±    0.145  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors                avgt    5  17088.024 ± 6469.083  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors_per_year       avgt    5   2218.779 ±  109.713  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_author            avgt    5     96.109 ±    2.215  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_year              avgt    5     22.282 ±    1.019  ms/op
PublicationStatisticsBenchmark.publication_with_the_most_authors            avgt    5     41.317 ±    0.211  ms/op
PublicationStatisticsBenchmark.publications_per_author                      avgt    5    234.659 ±   12.704  ms/op
PublicationStatisticsBenchmark.publications_with_the_most_authors_per_year  avgt    5     24.922 ±    0.343  ms/op
PublicationStatisticsBenchmark.publications_years_statistics                avgt    5     22.046 ±    1.128  ms/op
PublicationStatisticsBenchmark.year_with_the_most_publications              avgt    5     19.879 ±    0.447  ms/op
PublicationStatisticsBenchmark.years_with_the_most_publications             avgt    5     20.753 ±    0.453  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                                                                   Mode  Cnt      Score      Error  Units
PublicationStatisticsBenchmark.author_with_the_most_publications            avgt    5    108.937 ±   78.080  ms/op
PublicationStatisticsBenchmark.authors_with_no_duplicate_collaborations     avgt    5    117.442 ±    6.861  ms/op
PublicationStatisticsBenchmark.first_publication_year                       avgt    5     14.615 ±   11.093  ms/op
PublicationStatisticsBenchmark.last_publication_year                        avgt    5     14.308 ±   11.829  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors                avgt    5  13468.032 ± 2083.535  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors_per_year       avgt    5   1956.724 ±  646.748  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_author            avgt    5     96.300 ±   83.915  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_year              avgt    5     15.946 ±    0.067  ms/op
PublicationStatisticsBenchmark.publication_with_the_most_authors            avgt    5     39.526 ±    3.113  ms/op
PublicationStatisticsBenchmark.publications_per_author                      avgt    5    149.663 ±    4.625  ms/op
PublicationStatisticsBenchmark.publications_with_the_most_authors_per_year  avgt    5     21.952 ±    1.672  ms/op
PublicationStatisticsBenchmark.publications_years_statistics                avgt    5     25.517 ±    1.494  ms/op
PublicationStatisticsBenchmark.year_with_the_most_publications              avgt    5     16.569 ±    0.393  ms/op
PublicationStatisticsBenchmark.years_with_the_most_publications             avgt    5     17.077 ±    0.739  ms/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                                                                   Mode  Cnt      Score      Error  Units
PublicationStatisticsBenchmark.author_with_the_most_publications            avgt    5    131.368 ±   12.534  ms/op
PublicationStatisticsBenchmark.authors_with_no_duplicate_collaborations     avgt    5    177.536 ±   14.547  ms/op
PublicationStatisticsBenchmark.first_publication_year                       avgt    5      8.223 ±    1.378  ms/op
PublicationStatisticsBenchmark.last_publication_year                        avgt    5      8.182 ±    1.130  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors                avgt    5  19492.453 ± 1036.165  ms/op
PublicationStatisticsBenchmark.most_prolific_pair_of_authors_per_year       avgt    5   2139.255 ±  224.483  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_author            avgt    5    122.516 ±   34.398  ms/op
PublicationStatisticsBenchmark.number_of_publications_per_year              avgt    5     13.101 ±    8.228  ms/op
PublicationStatisticsBenchmark.publication_with_the_most_authors            avgt    5     38.175 ±    6.337  ms/op
PublicationStatisticsBenchmark.publications_per_author                      avgt    5    175.739 ±   16.855  ms/op
PublicationStatisticsBenchmark.publications_with_the_most_authors_per_year  avgt    5     17.923 ±    0.367  ms/op
PublicationStatisticsBenchmark.publications_years_statistics                avgt    5     21.993 ±    0.283  ms/op
PublicationStatisticsBenchmark.year_with_the_most_publications              avgt    5      8.956 ±    0.815  ms/op
PublicationStatisticsBenchmark.years_with_the_most_publications             avgt    5     11.333 ±    0.529  ms/op

