### PR TITLE
Add MessageDigestBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/messagedigest/MessageDigestBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/messagedigest/MessageDigestBenchmark.java
@@ -57,7 +57,7 @@ public class MessageDigestBenchmark {
 
   private final Random random = new Random(16384);
 
-  @Param({"64", "16384"})
+  @Param({"16384"})
   private int length;
 
   @Param({

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/messagedigest/MessageDigestBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/messagedigest/MessageDigestBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.messagedigest;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Generates a message digest (i.e., a hash representation) for an input byte array using various algorithms (e.g., MD5, SHA, SHA3).
+ * No explicit provider is declared; thus, the standard JDK provider is utilized.
+ *
+ * References:
+ * - https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#messagedigest-algorithms
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
+@State(Scope.Benchmark)
+public class MessageDigestBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*MessageDigestBenchmark.*"
+
+  private final Random random = new Random(16384);
+
+  @Param({"64", "16384"})
+  private int length;
+
+  @Param({
+    "MD5",
+    "SHA-1",
+    "SHA-224",
+    "SHA-256",
+    "SHA-384",
+    "SHA-512/224",
+    "SHA-512/256",
+    "SHA3-224",
+    "SHA3-256",
+    "SHA3-384",
+    "SHA3-512"
+  })
+  private String algorithm;
+
+  private byte[] input;
+  private MessageDigest messageDigest;
+
+  @Setup
+  public void setup() throws NoSuchAlgorithmException {
+    input = new byte[length];
+    random.nextBytes(input);
+    messageDigest = MessageDigest.getInstance(algorithm);
+  }
+
+  @Benchmark
+  public byte[] digest() {
+    return messageDigest.digest(input);
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                      (algorithm)  (length)  Mode  Cnt    Score    Error  Units
MessageDigestBenchmark.digest          MD5     16384  avgt    5   96.876 ±  5.893  us/op
MessageDigestBenchmark.digest        SHA-1     16384  avgt    5  154.232 ± 17.323  us/op
MessageDigestBenchmark.digest      SHA-224     16384  avgt    5  122.041 ±  2.805  us/op
MessageDigestBenchmark.digest      SHA-256     16384  avgt    5  121.749 ±  0.852  us/op
MessageDigestBenchmark.digest      SHA-384     16384  avgt    5   85.099 ±  1.020  us/op
MessageDigestBenchmark.digest  SHA-512/224     16384  avgt    5   84.449 ±  1.509  us/op
MessageDigestBenchmark.digest  SHA-512/256     16384  avgt    5   84.721 ±  0.857  us/op
MessageDigestBenchmark.digest     SHA3-224     16384  avgt    5  291.436 ±  3.523  us/op
MessageDigestBenchmark.digest     SHA3-256     16384  avgt    5  308.490 ±  5.190  us/op
MessageDigestBenchmark.digest     SHA3-384     16384  avgt    5  395.592 ±  2.619  us/op
MessageDigestBenchmark.digest     SHA3-512     16384  avgt    5  565.528 ± 91.730  us/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                      (algorithm)  (length)  Mode  Cnt    Score    Error  Units
MessageDigestBenchmark.digest          MD5     16384  avgt    5   95.903 ±  0.775  us/op
MessageDigestBenchmark.digest        SHA-1     16384  avgt    5  151.148 ±  0.894  us/op
MessageDigestBenchmark.digest      SHA-224     16384  avgt    5  120.889 ±  0.624  us/op
MessageDigestBenchmark.digest      SHA-256     16384  avgt    5  121.320 ±  0.554  us/op
MessageDigestBenchmark.digest      SHA-384     16384  avgt    5   84.407 ±  1.005  us/op
MessageDigestBenchmark.digest  SHA-512/224     16384  avgt    5   86.712 ±  7.333  us/op
MessageDigestBenchmark.digest  SHA-512/256     16384  avgt    5   84.688 ±  1.355  us/op
MessageDigestBenchmark.digest     SHA3-224     16384  avgt    5  274.351 ±  3.600  us/op
MessageDigestBenchmark.digest     SHA3-256     16384  avgt    5  290.973 ±  2.958  us/op
MessageDigestBenchmark.digest     SHA3-384     16384  avgt    5  381.012 ±  7.266  us/op
MessageDigestBenchmark.digest     SHA3-512     16384  avgt    5  550.648 ± 14.158  us/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                      (algorithm)  (length)  Mode  Cnt    Score     Error  Units
MessageDigestBenchmark.digest          MD5     16384  avgt    5   67.745 ±   0.221  us/op
MessageDigestBenchmark.digest        SHA-1     16384  avgt    5  241.474 ±   1.308  us/op
MessageDigestBenchmark.digest      SHA-224     16384  avgt    5  122.779 ±   1.788  us/op
MessageDigestBenchmark.digest      SHA-256     16384  avgt    5  122.266 ±   2.512  us/op
MessageDigestBenchmark.digest      SHA-384     16384  avgt    5   87.318 ±   1.999  us/op
MessageDigestBenchmark.digest  SHA-512/224     16384  avgt    5   86.247 ±   1.466  us/op
MessageDigestBenchmark.digest  SHA-512/256     16384  avgt    5   86.159 ±   1.396  us/op
MessageDigestBenchmark.digest     SHA3-224     16384  avgt    5  480.663 ± 141.662  us/op
MessageDigestBenchmark.digest     SHA3-256     16384  avgt    5  341.529 ±  73.699  us/op
MessageDigestBenchmark.digest     SHA3-384     16384  avgt    5  427.787 ±  11.658  us/op
MessageDigestBenchmark.digest     SHA3-512     16384  avgt    5  621.844 ±   8.201  us/op

