### PR TITLE
Add GameOfLifeBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/GameOfLifeBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/GameOfLifeBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.gameoflife;
+
+import com.ionutbalosin.jvm.performance.benchmarks.macro.gameoflife.functional.FunctionalGameOfLife;
+import com.ionutbalosin.jvm.performance.benchmarks.macro.gameoflife.iterative.IterativeGameOfLife;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Conway's Game of Life, often referred to simply as the Game of Life, is a cellular automaton devised by mathematician John Conway in 1970.
+ * It is a mathematical "zero-player" game, meaning that its evolution is determined by its initial state, with no further input required.
+ *
+ * The Game of Life is played on a 2D grid of cells, where each cell can be in one of two states: alive or dead (0 or 1).
+ * The game progresses through generations, with the state of each cell in a generation being determined by the state of its neighboring cells
+ * in the previous generation according to a set of rules. These rules are based on the concept of birth, death, and survival:
+ * - Birth: A dead cell with exactly three live neighbors becomes a live.
+ * - Death: A live cell with fewer than two live neighbors (underpopulation) or more than three live neighbors (overpopulation) becomes a dead cell.
+ * - Survival: A live cell with two or three live neighbors remains alive.
+ *
+ * Despite its simple rules, the Game of Life can produce complex and intricate patterns, including gliders (moving structures),
+ * oscillators (repeating patterns), and even structures that can act as logic gates and memory cells.
+ *
+ * The benchmark involves several alternative strategies:
+ * - Game of Life with Functional Programming
+ * - Game of Life with Imperative Style
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
+@State(Scope.Benchmark)
+public class GameOfLifeBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*GameOfLifeBenchmark.*"
+
+  private final int ROWS = 24;
+  private final int COLS = 24;
+  private final int GENERATIONS = 2048;
+  private final Random random = new Random(16384);
+  private byte[][] grid;
+
+  @Setup()
+  public void setup() {
+    grid = new byte[ROWS][COLS];
+    for (int i = 0; i < ROWS; i++) {
+      for (int j = 0; j < COLS; j++) {
+        grid[i][j] = (byte) (random.nextBoolean() == true ? 1 : 0);
+      }
+    }
+
+    // make sure the results are valid
+    sanityCheck(
+        FunctionalGameOfLife.evolve(grid, GENERATIONS),
+        IterativeGameOfLife.evolve(grid, GENERATIONS));
+  }
+
+  @Benchmark
+  public byte[][] functional() {
+    return FunctionalGameOfLife.evolve(grid, GENERATIONS);
+  }
+
+  @Benchmark
+  public byte[][] iterative() {
+    return IterativeGameOfLife.evolve(grid, GENERATIONS);
+  }
+
+  /**
+   * Sanity check for the results to avoid wrong benchmarks comparisons
+   *
+   * @param val1 - first evolved population
+   * @param val2 - second evolved population
+   */
+  private void sanityCheck(byte[][] val1, byte[][] val2) {
+    for (int i = 0; i < ROWS; i++) {
+      for (int j = 0; j < COLS; j++) {
+        if (val1[i][j] != val2[i][j]) {
+          throw new AssertionError("Generated population contains different values.");
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/functional/FunctionalGameOfLife.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/functional/FunctionalGameOfLife.java
@@ -1,0 +1,74 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.gameoflife.functional;
+
+import java.util.stream.IntStream;
+
+public class FunctionalGameOfLife {
+
+  public static byte[][] evolve(byte[][] grid, int generations) {
+    return IntStream.range(0, generations)
+        .mapToObj(gen -> evolveGeneration(grid))
+        .reduce((prevGrid, currentGrid) -> currentGrid)
+        .orElse(grid);
+  }
+
+  private static byte[][] evolveGeneration(byte[][] grid) {
+    final int rows = grid.length;
+    final int cols = grid[0].length;
+    final byte[][] newGrid = new byte[rows][cols];
+
+    IntStream.range(0, rows)
+        .parallel()
+        .forEach(
+            row ->
+                IntStream.range(0, cols)
+                    .forEach(col -> newGrid[row][col] = evolveCell(grid, row, col)));
+
+    System.arraycopy(newGrid, 0, grid, 0, rows);
+    return grid;
+  }
+
+  private static byte evolveCell(byte[][] grid, int row, int col) {
+    final int rows = grid.length;
+    final int cols = grid[0].length;
+
+    byte neighbors =
+        (byte)
+            IntStream.rangeClosed(row - 1, row + 1)
+                .flatMap(
+                    r ->
+                        IntStream.rangeClosed(col - 1, col + 1)
+                            .filter(c -> r >= 0 && r < rows && c >= 0 && c < cols)
+                            .filter(c -> !(r == row && c == col))
+                            .map(c -> grid[r][c]))
+                .filter(cell -> cell == 1)
+                .count();
+
+    if (grid[row][col] == 1) {
+      return (byte) (neighbors == 2 || neighbors == 3 ? 1 : 0);
+    } else {
+      return (byte) (neighbors == 3 ? 1 : 0);
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/iterative/IterativeGameOfLife.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/gameoflife/iterative/IterativeGameOfLife.java
@@ -1,0 +1,70 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.gameoflife.iterative;
+
+public class IterativeGameOfLife {
+
+  public static byte[][] evolve(byte[][] grid, int generations) {
+    for (int gen = 0; gen < generations; gen++) {
+      grid = evolveGeneration(grid);
+    }
+    return grid;
+  }
+
+  private static byte[][] evolveGeneration(byte[][] grid) {
+    final int rows = grid.length;
+    final int cols = grid[0].length;
+    final byte[][] newGrid = new byte[rows][cols];
+
+    for (int row = 0; row < rows; row++) {
+      for (int col = 0; col < cols; col++) {
+        newGrid[row][col] = evolveCell(grid, row, col);
+      }
+    }
+
+    System.arraycopy(newGrid, 0, grid, 0, grid.length);
+    return grid;
+  }
+
+  private static byte evolveCell(byte[][] grid, int row, int col) {
+    final int rows = grid.length;
+    final int cols = grid[0].length;
+    byte neighbors = 0;
+
+    for (int r = row - 1; r <= row + 1; r++) {
+      for (int c = col - 1; c <= col + 1; c++) {
+        if (r >= 0 && r < rows && c >= 0 && c < cols && !(r == row && c == col)) {
+          if (grid[r][c] == 1) {
+            neighbors++;
+          }
+        }
+      }
+    }
+
+    if (grid[row][col] == 1) {
+      return (byte) (neighbors == 2 || neighbors == 3 ? 1 : 0);
+    } else {
+      return (byte) (neighbors == 3 ? 1 : 0);
+    }
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                       Mode  Cnt     Score    Error  Units
GameOfLifeBenchmark.functional  avgt    5  1597.986 ± 11.958  ms/op
GameOfLifeBenchmark.iterative   avgt    5    89.445 ± 44.986  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                       Mode  Cnt    Score   Error  Units
GameOfLifeBenchmark.functional  avgt    5  678.433 ± 3.103  ms/op
GameOfLifeBenchmark.iterative   avgt    5   58.746 ± 1.114  ms/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                       Mode  Cnt    Score    Error  Units
GameOfLifeBenchmark.functional  avgt    5  561.379 ± 59.894  ms/op
GameOfLifeBenchmark.iterative   avgt    5   51.335 ±  8.366  ms/op


PS: this was not on the list initially but I could not resist implementing it. And there are some differences across the 3 JVMs/JITs tested