### PR TITLE
Extend/Update PrimesBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/prime/millerrabin/MillerRabin.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/prime/millerrabin/MillerRabin.java
@@ -1,0 +1,104 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.prime.millerrabin;
+
+import java.util.Random;
+
+public class MillerRabin {
+
+  // Number of iterations the test does to determine whether a given number is likely prime or not.
+  // Note: Number of iterations is a trade-off between computational efficiency and accuracy:
+  // - a larger number reduces the chances of false positives,
+  // - but it also increases the time it takes to perform the test.
+  private static final int ITERATIONS = 5;
+  private static final Random random = new Random(16384);
+
+  public static long primes(final int n) {
+    long numberOfPrimes = 0;
+    for (int num = 2; num <= n; num++) {
+      if (isPrime(num, ITERATIONS)) {
+        numberOfPrimes++;
+      }
+    }
+    return numberOfPrimes;
+  }
+
+  private static boolean isPrime(long n, int k) {
+    if (n <= 1 || n == 4) {
+      return false;
+    }
+    if (n <= 3) {
+      return true;
+    }
+
+    long d = n - 1;
+    while (d % 2 == 0) {
+      d /= 2;
+    }
+
+    for (int i = 0; i < k; i++) {
+      final long a = 2 + random.nextInt((int) (n - 4));
+      long x = power(a, d, n);
+
+      if (x == 1 || x == n - 1) {
+        continue;
+      }
+
+      boolean found = false;
+      while (d != n - 1) {
+        x = (x * x) % n;
+        d *= 2;
+
+        if (x == 1) {
+          return false;
+        }
+        if (x == n - 1) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Returns (x^y) % p
+  private static long power(long x, long y, long p) {
+    long result = 1;
+    x = x % p;
+
+    while (y > 0) {
+      if (y % 2 == 1) {
+        result = (result * x) % p;
+      }
+      y = y >> 1; // y = y / 2
+      x = (x * x) % p;
+    }
+
+    return result;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/prime/trialdivision/StreamBasedTrialDivision.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/prime/trialdivision/StreamBasedTrialDivision.java
@@ -20,15 +20,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.ionutbalosin.jvm.performance.benchmarks.macro.prime.stream;
+package com.ionutbalosin.jvm.performance.benchmarks.macro.prime.trialdivision;
 
 import static java.lang.Math.sqrt;
 import static java.util.stream.IntStream.range;
 
-public class SqrtStreamFilter {
+public class StreamBasedTrialDivision {
 
   public static long primes(final int n) {
-    return range(2, n).filter(SqrtStreamFilter::isPrime).count();
+    return range(2, n).filter(StreamBasedTrialDivision::isPrime).count();
   }
 
   private static boolean isPrime(final int n) {


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                               (n)  Mode  Cnt      Score     Error  Units
PrimesBenchmark.eratosthenes_sieve  8388608  avgt    3     92.352 ±   9.720  ms/op
PrimesBenchmark.miller_rabin        8388608  avgt    3  11724.555 ± 545.573  ms/op
PrimesBenchmark.trial_division      8388608  avgt    3  14592.842 ± 787.225  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                               (n)  Mode  Cnt      Score     Error  Units
PrimesBenchmark.eratosthenes_sieve  8388608  avgt    3     77.451 ±  23.147  ms/op
PrimesBenchmark.miller_rabin        8388608  avgt    3  10977.275 ± 558.573  ms/op
PrimesBenchmark.trial_division      8388608  avgt    3  12938.781 ± 134.032  ms/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                               (n)  Mode  Cnt      Score     Error  Units
PrimesBenchmark.eratosthenes_sieve  8388608  avgt    3     97.306 ±  76.160  ms/op
PrimesBenchmark.miller_rabin        8388608  avgt    3  11468.530 ± 302.589  ms/op
PrimesBenchmark.trial_division      8388608  avgt    3   9793.629 ± 433.960  ms/op

---

In a nutshell:
- add a new method miller_rabin
- refactor the existing sqrt_stream -> trial_division
