### PR TITLE
Add LzwCodecBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodec.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodec.java
@@ -1,0 +1,34 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec;
+
+public class LzwCodec {
+
+  public static final int ISO_8859_1 = 0xFF;
+
+  public static char[] resizeArray(char[] array, int newSize) {
+    final char[] newArray = new char[newSize];
+    System.arraycopy(array, 0, newArray, 0, Math.min(array.length, newSize));
+    return newArray;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodecBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodecBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.ISO_8859_1;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCompress.compressData;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwDecompress.decompressData;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * LZW (Lempel-Ziv-Welch) Compression and Decompression Algorithm
+ *
+ * The LZW algorithm is a lossless data compression technique used to reduce the size of data by encoding repetitive patterns in a more efficient manner.
+ *
+ * The algorithm consists of two main operations: compression and decompression:
+ *
+ * - The compression process involves converting a sequence of characters into a sequence of variable-length codes.
+ * The algorithm initializes a dictionary containing single-character entries. It then processes the input data one character at a time.
+ * A current sequence of characters is built by appending characters to the existing sequence.
+ * If the current sequence is present in the dictionary, it is extended by adding the next character.
+ * If the sequence is not found, its code is emitted, and a new entry is added to the dictionary.
+ * The compression process continues until all input characters are processed.
+ *
+ * - The decompression process involves converting the variable-length codes back into the original sequence of characters.
+ * Similar to compression, the algorithm initializes a dictionary containing single-character entries.
+ * It processes the input codes one by one, looking up the corresponding sequence in the dictionary.
+ * If the sequence is present, it is appended to the decompressed output. If not, a new sequence is created by concatenating
+ * the previous sequence with its first character. The new sequence is then added to the dictionary for future reference.
+ * The decompression process continues until all input codes are processed.
+ *
+ * Limitations:
+ * - LZW may not be as efficient for data with little to no repetitive patterns (i.e., LZW is optimized for repetitive patterns).
+ * - The compression dictionary size can grow large for longer input data, leading to increased memory usage.
+ *
+ * Important:
+ * - In the current implementation, the generated input char array follows a repetitive pattern.
+ * Generating input without a repetitive pattern might require a more complex (i.e., an improved) version of the current LZW algorithm.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class LzwCodecBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*LzwCodecBenchmark.*"
+
+  private final Random random = new Random(16384);
+
+  private char[] data, dataCompressed, dataDecompressed;
+
+  @Param({"262144"})
+  private int dataSize;
+
+  @Setup()
+  public void setup() {
+    // initialize data
+    data = charArray(dataSize);
+
+    // compress/decompress data
+    dataCompressed = compressData(data);
+    dataDecompressed = decompressData(dataCompressed);
+
+    // make sure the results are equivalent before any further benchmarking
+    sanityCheck(data, dataCompressed, dataDecompressed);
+  }
+
+  @Benchmark
+  public char[] compress() {
+    return compressData(data);
+  }
+
+  @Benchmark
+  public char[] decompress() {
+    return decompressData(dataCompressed);
+  }
+
+  private char[] charArray(int length) {
+    final char[] charArray = new char[length];
+    int threshold = random.nextInt(ISO_8859_1 + 1);
+
+    for (int i = 0; i < length; i++) {
+      // Generate (on purpose) a repetitive pattern of characters
+      charArray[i] = (char) (i % threshold);
+    }
+
+    return charArray;
+  }
+
+  /**
+   * Sanity check for the results to avoid wrong benchmarks comparisons
+   *
+   * @param input - source char array to compress
+   * @param compressed - compressed char array
+   * @param decompressed - decompressed char array
+   */
+  private void sanityCheck(char[] input, char[] compressed, char[] decompressed) {
+    if (compressed.length >= input.length) {
+      throw new AssertionError("Compressed array is bigger than the source array.");
+    }
+
+    if (input.length != decompressed.length) {
+      throw new AssertionError("Arrays have different length.");
+    }
+
+    for (int i = 0; i < input.length; i++) {
+      if (input[i] != decompressed[i]) {
+        throw new AssertionError("Array values are different.");
+      }
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodecBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCodecBenchmark.java
@@ -71,9 +71,9 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class LzwCodecBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCompress.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCompress.java
@@ -22,14 +22,13 @@
  */
 package com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec;
 
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.ISO_8859_1;
 import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.resizeArray;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class LzwCompress {
-
-  private static final int ISO_8859_1 = 0xFF;
 
   /**
    * Compresses the input character array using the LZW compression algorithm.

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCompress.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwCompress.java
@@ -1,0 +1,103 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.resizeArray;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LzwCompress {
+
+  private static final int ISO_8859_1 = 0xFF;
+
+  /**
+   * Compresses the input character array using the LZW compression algorithm.
+   *
+   * @param input The input character array to be compressed.
+   * @return A compressed character array using LZW algorithm.
+   */
+  public static char[] compressData(char[] input) {
+    // Create a dictionary to store codes and their corresponding strings
+    final Map<String, Integer> dictionary = new HashMap<>();
+    int nextCode = 0;
+
+    // Initialize dictionary with individual characters
+    for (char ch = 0; ch <= ISO_8859_1; ch++) {
+      dictionary.put(String.valueOf(ch), nextCode++);
+    }
+
+    // Initialize variables for current sequence and compressed data
+    char[] current = new char[0];
+    final char[] compressed = new char[input.length];
+    int compressedIndex = 0;
+
+    // Iterate through input characters to perform compression
+    for (char ch : input) {
+      // Concatenate current sequence with the current character
+      char[] currentPlusCh = new char[current.length + 1];
+      System.arraycopy(current, 0, currentPlusCh, 0, current.length);
+      currentPlusCh[current.length] = ch;
+
+      // Convert the concatenated sequence to a string
+      String currentPlusChString = new String(currentPlusCh);
+
+      // Check if the current sequence is in the dictionary
+      if (dictionary.containsKey(currentPlusChString)) {
+        // Update the current sequence with the concatenated sequence
+        current = currentPlusCh;
+      } else {
+        // Append the code for the current sequence to the compressed data
+        compressedIndex =
+            addCodeToCompressed(compressed, compressedIndex, dictionary.get(new String(current)));
+
+        // Add the new sequence to the dictionary and update current sequence
+        dictionary.put(currentPlusChString, nextCode++);
+        current = new char[] {ch};
+      }
+    }
+    // Append the code for the final current sequence to the compressed data
+    compressedIndex =
+        addCodeToCompressed(compressed, compressedIndex, dictionary.get(new String(current)));
+
+    return resizeArray(compressed, compressedIndex);
+  }
+
+  /**
+   * Adds a code to the compressed data array and handles resizing if necessary.
+   *
+   * @param compressed The compressed data array.
+   * @param index The current index in the compressed data array.
+   * @param code The code to be added to the compressed data.
+   * @return The updated index in the compressed data array.
+   */
+  private static int addCodeToCompressed(char[] compressed, int index, Integer code) {
+    // Check if the current index is at the end of the array
+    if (index == compressed.length) {
+      compressed = resizeArray(compressed, index * 2);
+    }
+    compressed[index++] = (char) code.intValue();
+
+    return index;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwDecompress.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/lzwcodec/LzwDecompress.java
@@ -1,0 +1,89 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec;
+
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.ISO_8859_1;
+import static com.ionutbalosin.jvm.performance.benchmarks.macro.lzwcodec.LzwCodec.resizeArray;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LzwDecompress {
+
+  /**
+   * Decompresses the given compressed data array using the LZW algorithm.
+   *
+   * @param compressed The compressed data array to be decompressed.
+   * @return The decompressed data array.
+   */
+  public static char[] decompressData(char[] compressed) {
+    // Initialize the dictionary for decompression
+    final Map<Integer, String> dictionary = new HashMap<>();
+    int nextCode = 0;
+
+    // Populate the dictionary with single-character entries
+    for (char ch = 0; ch <= ISO_8859_1; ch++) {
+      dictionary.put(nextCode++, String.valueOf(ch));
+    }
+
+    // Initialize the array to hold the decompressed data
+    char[] decompressed = new char[compressed.length * 2];
+    int decompressedIndex = 0;
+
+    // Initialize the previous code and append its corresponding character to the decompressed array
+    int prevCode = compressed[0];
+    decompressed[decompressedIndex++] = dictionary.get(prevCode).charAt(0);
+
+    // Iterate through the compressed data array to perform decompression
+    for (int i = 1; i < compressed.length; i++) {
+      final int code = compressed[i];
+      final String entry;
+
+      // Check if the dictionary contains the current code
+      if (dictionary.containsKey(code)) {
+        entry = dictionary.get(code);
+      } else {
+        // Create a new entry using the previous code and its first character
+        entry = dictionary.get(prevCode) + dictionary.get(prevCode).charAt(0);
+      }
+
+      // Append each character of the entry to the decompressed array
+      for (char ch : entry.toCharArray()) {
+        // Check if the decompressed array is full, and resize it if necessary
+        if (decompressedIndex == decompressed.length) {
+          decompressed = resizeArray(decompressed, decompressedIndex * 2);
+        }
+        // Add the character to the decompressed array and update the index
+        decompressed[decompressedIndex++] = ch;
+      }
+
+      // Add a new entry to the dictionary by concatenating the previous entry and the first
+      // character of the current entry
+      dictionary.put(nextCode++, dictionary.get(prevCode) + entry.charAt(0));
+      prevCode = code; // Update the previous code for the next iteration
+    }
+
+    // Resize the decompressed array to the correct size and return it
+    return resizeArray(decompressed, decompressedIndex);
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                     (dataSize)  Mode  Cnt   Score   Error  Units
LzwCodecBenchmark.compress        262144  avgt    3  76.933 ± 5.101  ms/op
LzwCodecBenchmark.decompress      262144  avgt    3   3.229 ± 0.406  ms/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                     (dataSize)  Mode  Cnt   Score   Error  Units
LzwCodecBenchmark.compress        262144  avgt    3  76.488 ± 3.576  ms/op
LzwCodecBenchmark.decompress      262144  avgt    3   1.966 ± 0.170  ms/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                     (dataSize)  Mode  Cnt   Score    Error  Units
LzwCodecBenchmark.compress        262144  avgt    3  85.121 ± 64.229  ms/op
LzwCodecBenchmark.decompress      262144  avgt    3   4.380 ±  3.718  ms/op