### PR TITLE
Add EnumSwitchBenchmark/StringSwitchBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/EnumSwitchBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/EnumSwitchBenchmark.java
@@ -1,0 +1,319 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.micro.compiler;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Test the performance of enum matching using different approaches:
+ * - Switch statements
+ * - Switch expressions
+ * - If-else statements
+ *
+ * Switch-case statements are internally implemented using either the tableswitch or lookupswitch bytecode instructions:
+ * - The tableswitch instruction is employed for a narrow, contiguous range of values.
+ * It involves branching with a jump over a jump-table defined by sorted, continuous integer values.
+ * - The lookupswitch instruction is employed for a wider range of values. It facilitates branching based on a map of key-offset pairs.
+ * While not as efficient as the tableswitch instruction, it enables branching on individual values, rather than continuous ranges.
+ *
+ * The choice between emitting a tableswitch or a lookupswitch instruction depends on the trade-off between time and space complexity costs for each instruction.
+ * The compiler will opt for the tableswitch instruction if the associated space and time costs are lower or equal to those of the lookupswitch.
+ * The overall space/time cost for a specific instruction is calculated using the formula: spaceCost + timeCost * 3.
+ *
+ *  +---------------+---------------------+-------------+
+ *  |  Opcode       |  Space cost         |  Time cost  |
+ *  +---------------+---------------------+-------------+
+ *  |  tableswitch  |  4 + (hi - lo + 1)  |  3          |
+ *  +---------------+---------------------+-------------+
+ *  |  lookupswitch |  3 + 2 * nlabels    |  nlabels    |
+ *  +---------------+---------------------+-------------+
+ * where:
+ * - hi and lo parameters are the highest and lowest value switch keys used in the switch statement
+ * - nlabels is the number of switch keys
+ *
+ *  References:
+ * - https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java#L1347
+ * - https://github.com/ndru83/desugaring-java/blob/master/switch-case-internals.adoc
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class EnumSwitchBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*EnumSwitchBenchmark.*"
+
+  private final int SIZE = 1024;
+  private final Vehicle[] CACHED_VEHICLES = Vehicle.values();
+
+  @Param({"3", "6", "12", "24"})
+  private int branches;
+
+  private Vehicle[] vehicles;
+
+  @Setup()
+  public void setup() {
+    vehicles = new Vehicle[SIZE];
+
+    for (int i = 0; i < SIZE; i += 1) {
+      vehicles[i] = CACHED_VEHICLES[i % branches];
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int switch_statements() {
+    int sum = 0;
+    for (Vehicle vehicle : vehicles) {
+      sum += switchStatements(vehicle);
+    }
+    return sum;
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int switch_expressions() {
+    int sum = 0;
+    for (Vehicle vehicle : vehicles) {
+      sum += switchExpressions(vehicle);
+    }
+    return sum;
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int chained_ifs() {
+    int sum = 0;
+    for (Vehicle vehicle : vehicles) {
+      sum += chainedIfs(vehicle);
+    }
+    return sum;
+  }
+
+  private int switchStatements(Vehicle vehicle) {
+    int result = 0;
+
+    switch (vehicle) {
+      case MOPED:
+        result = 1;
+        break;
+      case BICYCLE:
+        result = 2;
+        break;
+      case ELECTRIC_SCOOTER:
+        result = 3;
+        break;
+      case MOTORCYCLE:
+        result = 4;
+        break;
+      case CAR:
+        result = 5;
+        break;
+      case SUV:
+        result = 6;
+        break;
+      case VAN:
+        result = 7;
+        break;
+      case MOTOR_HOME:
+        result = 8;
+        break;
+      case TRUCK:
+        result = 9;
+        break;
+      case BUS:
+        result = 10;
+        break;
+      case TRACTOR:
+        result = 11;
+        break;
+      case MONORAIL:
+        result = 12;
+        break;
+      case TRAIN:
+        result = 13;
+        break;
+      case JET_SKI:
+        result = 14;
+        break;
+      case SKATEBOARD:
+        result = 15;
+        break;
+      case HOVERBOARD:
+        result = 16;
+        break;
+      case BOAT:
+        result = 17;
+        break;
+      case CATAMARAN:
+        result = 18;
+        break;
+      case SUBMARINE:
+        result = 19;
+        break;
+      case HOT_AIR_BALLOON:
+        result = 20;
+        break;
+      case AIRPLANE:
+        result = 21;
+        break;
+      case HELICOPTER:
+        result = 22;
+        break;
+      case SPACE_SHUTTLE:
+        result = 23;
+        break;
+      case ROCKET:
+        result = 24;
+        break;
+    }
+
+    return result;
+  }
+
+  private int switchExpressions(Vehicle vehicle) {
+    return switch (vehicle) {
+      case MOPED -> 1;
+      case BICYCLE -> 2;
+      case ELECTRIC_SCOOTER -> 3;
+      case MOTORCYCLE -> 4;
+      case CAR -> 5;
+      case SUV -> 6;
+      case VAN -> 7;
+      case MOTOR_HOME -> 8;
+      case TRUCK -> 9;
+      case BUS -> 10;
+      case TRACTOR -> 11;
+      case MONORAIL -> 12;
+      case TRAIN -> 13;
+      case JET_SKI -> 14;
+      case SKATEBOARD -> 15;
+      case HOVERBOARD -> 16;
+      case BOAT -> 17;
+      case CATAMARAN -> 18;
+      case SUBMARINE -> 19;
+      case HOT_AIR_BALLOON -> 20;
+      case AIRPLANE -> 21;
+      case HELICOPTER -> 22;
+      case SPACE_SHUTTLE -> 23;
+      case ROCKET -> 24;
+    };
+  }
+
+  private int chainedIfs(Vehicle vehicle) {
+    int result = 0;
+
+    if (vehicle == Vehicle.MOPED) {
+      result = 1;
+    } else if (vehicle == Vehicle.BICYCLE) {
+      result = 2;
+    } else if (vehicle == Vehicle.ELECTRIC_SCOOTER) {
+      result = 3;
+    } else if (vehicle == Vehicle.MOTORCYCLE) {
+      result = 4;
+    } else if (vehicle == Vehicle.CAR) {
+      result = 5;
+    } else if (vehicle == Vehicle.SUV) {
+      result = 6;
+    } else if (vehicle == Vehicle.VAN) {
+      result = 7;
+    } else if (vehicle == Vehicle.MOTOR_HOME) {
+      result = 8;
+    } else if (vehicle == Vehicle.TRUCK) {
+      result = 9;
+    } else if (vehicle == Vehicle.BUS) {
+      result = 10;
+    } else if (vehicle == Vehicle.TRACTOR) {
+      result = 11;
+    } else if (vehicle == Vehicle.MONORAIL) {
+      result = 12;
+    } else if (vehicle == Vehicle.TRAIN) {
+      result = 13;
+    } else if (vehicle == Vehicle.JET_SKI) {
+      result = 14;
+    } else if (vehicle == Vehicle.SKATEBOARD) {
+      result = 15;
+    } else if (vehicle == Vehicle.HOVERBOARD) {
+      result = 16;
+    } else if (vehicle == Vehicle.BOAT) {
+      result = 17;
+    } else if (vehicle == Vehicle.CATAMARAN) {
+      result = 18;
+    } else if (vehicle == Vehicle.SUBMARINE) {
+      result = 19;
+    } else if (vehicle == Vehicle.HOT_AIR_BALLOON) {
+      result = 20;
+    } else if (vehicle == Vehicle.AIRPLANE) {
+      result = 21;
+    } else if (vehicle == Vehicle.HELICOPTER) {
+      result = 22;
+    } else if (vehicle == Vehicle.SPACE_SHUTTLE) {
+      result = 23;
+    } else if (vehicle == Vehicle.ROCKET) {
+      result = 24;
+    }
+
+    return result;
+  }
+
+  public enum Vehicle {
+    MOPED,
+    BICYCLE,
+    ELECTRIC_SCOOTER,
+    MOTORCYCLE,
+    CAR,
+    SUV,
+    VAN,
+    MOTOR_HOME,
+    TRUCK,
+    BUS,
+    TRACTOR,
+    MONORAIL,
+    TRAIN,
+    JET_SKI,
+    SKATEBOARD,
+    HOVERBOARD,
+    BOAT,
+    CATAMARAN,
+    SUBMARINE,
+    HOT_AIR_BALLOON,
+    AIRPLANE,
+    HELICOPTER,
+    SPACE_SHUTTLE,
+    ROCKET
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/EnumSwitchBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/EnumSwitchBenchmark.java
@@ -69,9 +69,9 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class EnumSwitchBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StringSwitchBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StringSwitchBenchmark.java
@@ -1,0 +1,294 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.micro.compiler;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Test the performance of String matching using different approaches:
+ * - Switch statements
+ * - Switch expressions
+ * - If-else statements
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class StringSwitchBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*StringSwitchBenchmark.*"
+
+  private final int SIZE = 1024;
+  private final String[] VEHICLES =
+      new String[] {
+        "MOPED",
+        "BICYCLE",
+        "ELECTRIC_SCOOTER",
+        "MOTORCYCLE",
+        "CAR",
+        "SUV",
+        "VAN",
+        "MOTOR_HOME",
+        "TRUCK",
+        "BUS",
+        "TRACTOR",
+        "MONORAIL",
+        "TRAIN",
+        "JET_SKI",
+        "SKATEBOARD",
+        "HOVERBOARD",
+        "BOAT",
+        "CATAMARAN",
+        "SUBMARINE",
+        "HOT_AIR_BALLOON",
+        "AIRPLANE",
+        "HELICOPTER",
+        "SPACE_SHUTTLE",
+        "ROCKET"
+      };
+
+  @Param({"3", "6", "12", "24"})
+  private int branches;
+
+  private String[] vehicles;
+
+  @Setup()
+  public void setup() {
+    vehicles = new String[SIZE];
+
+    for (int i = 0; i < SIZE; i += 1) {
+      vehicles[i] = VEHICLES[i % branches];
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int switch_statements() {
+    int sum = 0;
+    for (String vehicle : vehicles) {
+      sum += switchStatements(vehicle);
+    }
+    return sum;
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int switch_expressions() {
+    int sum = 0;
+    for (String vehicle : vehicles) {
+      sum += switchExpressions(vehicle);
+    }
+    return sum;
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(SIZE)
+  public int chained_ifs() {
+    int sum = 0;
+    for (String vehicle : vehicles) {
+      sum += chainedIfs(vehicle);
+    }
+    return sum;
+  }
+
+  private int switchStatements(String vehicle) {
+    int result = 0;
+
+    switch (vehicle) {
+      case "MOPED":
+        result = 1;
+        break;
+      case "BICYCLE":
+        result = 2;
+        break;
+      case "ELECTRIC_SCOOTER":
+        result = 3;
+        break;
+      case "MOTORCYCLE":
+        result = 4;
+        break;
+      case "CAR":
+        result = 5;
+        break;
+      case "SUV":
+        result = 6;
+        break;
+      case "VAN":
+        result = 7;
+        break;
+      case "MOTOR_HOME":
+        result = 8;
+        break;
+      case "TRUCK":
+        result = 9;
+        break;
+      case "BUS":
+        result = 10;
+        break;
+      case "TRACTOR":
+        result = 11;
+        break;
+      case "MONORAIL":
+        result = 12;
+        break;
+      case "TRAIN":
+        result = 13;
+        break;
+      case "JET_SKI":
+        result = 14;
+        break;
+      case "SKATEBOARD":
+        result = 15;
+        break;
+      case "HOVERBOARD":
+        result = 16;
+        break;
+      case "BOAT":
+        result = 17;
+        break;
+      case "CATAMARAN":
+        result = 18;
+        break;
+      case "SUBMARINE":
+        result = 19;
+        break;
+      case "HOT_AIR_BALLOON":
+        result = 20;
+        break;
+      case "AIRPLANE":
+        result = 21;
+        break;
+      case "HELICOPTER":
+        result = 22;
+        break;
+      case "SPACE_SHUTTLE":
+        result = 23;
+        break;
+      case "ROCKET":
+        result = 24;
+        break;
+    }
+
+    return result;
+  }
+
+  private int switchExpressions(String vehicle) {
+    return switch (vehicle) {
+      case "MOPED" -> 1;
+      case "BICYCLE" -> 2;
+      case "ELECTRIC_SCOOTER" -> 3;
+      case "MOTORCYCLE" -> 4;
+      case "CAR" -> 5;
+      case "SUV" -> 6;
+      case "VAN" -> 7;
+      case "MOTOR_HOME" -> 8;
+      case "TRUCK" -> 9;
+      case "BUS" -> 10;
+      case "TRACTOR" -> 11;
+      case "MONORAIL" -> 12;
+      case "TRAIN" -> 13;
+      case "JET_SKI" -> 14;
+      case "SKATEBOARD" -> 15;
+      case "HOVERBOARD" -> 16;
+      case "BOAT" -> 17;
+      case "CATAMARAN" -> 18;
+      case "SUBMARINE" -> 19;
+      case "HOT_AIR_BALLOON" -> 20;
+      case "AIRPLANE" -> 21;
+      case "HELICOPTER" -> 22;
+      case "SPACE_SHUTTLE" -> 23;
+      case "ROCKET" -> 24;
+      default -> 0;
+    };
+  }
+
+  private int chainedIfs(String vehicle) {
+    int result = 0;
+
+    if ("MOPED".equals(vehicle)) {
+      return 1;
+    } else if ("BICYCLE".equals(vehicle)) {
+      return 2;
+    } else if ("ELECTRIC_SCOOTER".equals(vehicle)) {
+      return 3;
+    } else if ("MOTORCYCLE".equals(vehicle)) {
+      return 4;
+    } else if ("CAR".equals(vehicle)) {
+      return 5;
+    } else if ("SUV".equals(vehicle)) {
+      return 6;
+    } else if ("VAN".equals(vehicle)) {
+      return 7;
+    } else if ("MOTOR_HOME".equals(vehicle)) {
+      return 8;
+    } else if ("TRUCK".equals(vehicle)) {
+      return 9;
+    } else if ("BUS".equals(vehicle)) {
+      return 10;
+    } else if ("TRACTOR".equals(vehicle)) {
+      return 11;
+    } else if ("MONORAIL".equals(vehicle)) {
+      return 12;
+    } else if ("TRAIN".equals(vehicle)) {
+      return 13;
+    } else if ("JET_SKI".equals(vehicle)) {
+      return 14;
+    } else if ("SKATEBOARD".equals(vehicle)) {
+      return 15;
+    } else if ("HOVERBOARD".equals(vehicle)) {
+      return 16;
+    } else if ("BOAT".equals(vehicle)) {
+      return 17;
+    } else if ("CATAMARAN".equals(vehicle)) {
+      return 18;
+    } else if ("SUBMARINE".equals(vehicle)) {
+      return 19;
+    } else if ("HOT_AIR_BALLOON".equals(vehicle)) {
+      return 20;
+    } else if ("AIRPLANE".equals(vehicle)) {
+      return 21;
+    } else if ("HELICOPTER".equals(vehicle)) {
+      return 22;
+    } else if ("SPACE_SHUTTLE".equals(vehicle)) {
+      return 23;
+    } else if ("ROCKET".equals(vehicle)) {
+      return 24;
+    }
+
+    return result;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StringSwitchBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StringSwitchBenchmark.java
@@ -44,9 +44,9 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class StringSwitchBenchmark {
 


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                               (branches)  Mode  Cnt   Score   Error  Units
EnumSwitchBenchmark.chained_ifs                  3  avgt    3   3.218 ± 2.348  ns/op
EnumSwitchBenchmark.chained_ifs                  6  avgt    3   4.355 ± 0.049  ns/op
EnumSwitchBenchmark.chained_ifs                 12  avgt    3   7.492 ± 0.598  ns/op
EnumSwitchBenchmark.chained_ifs                 24  avgt    3  12.035 ± 1.927  ns/op
EnumSwitchBenchmark.switch_expressions           3  avgt    3   3.984 ± 1.745  ns/op
EnumSwitchBenchmark.switch_expressions           6  avgt    3   5.175 ± 1.625  ns/op
EnumSwitchBenchmark.switch_expressions          12  avgt    3   6.392 ± 0.780  ns/op
EnumSwitchBenchmark.switch_expressions          24  avgt    3   5.835 ± 0.956  ns/op
EnumSwitchBenchmark.switch_statements            3  avgt    3   3.435 ± 0.068  ns/op
EnumSwitchBenchmark.switch_statements            6  avgt    3   5.288 ± 0.576  ns/op
EnumSwitchBenchmark.switch_statements           12  avgt    3   4.618 ± 0.495  ns/op
EnumSwitchBenchmark.switch_statements           24  avgt    3   5.726 ± 0.865  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                               (branches)  Mode  Cnt   Score    Error  Units
EnumSwitchBenchmark.chained_ifs                  3  avgt    3   3.022 ±  0.107  ns/op
EnumSwitchBenchmark.chained_ifs                  6  avgt    3   4.013 ±  0.045  ns/op
EnumSwitchBenchmark.chained_ifs                 12  avgt    3   7.008 ±  0.904  ns/op
EnumSwitchBenchmark.chained_ifs                 24  avgt    3  12.267 ±  0.431  ns/op
EnumSwitchBenchmark.switch_expressions           3  avgt    3   5.108 ±  0.476  ns/op
EnumSwitchBenchmark.switch_expressions           6  avgt    3   5.427 ±  0.384  ns/op
EnumSwitchBenchmark.switch_expressions          12  avgt    3   6.973 ± 12.165  ns/op
EnumSwitchBenchmark.switch_expressions          24  avgt    3   5.934 ±  1.004  ns/op
EnumSwitchBenchmark.switch_statements            3  avgt    3   5.218 ±  0.414  ns/op
EnumSwitchBenchmark.switch_statements            6  avgt    3   5.586 ±  0.500  ns/op
EnumSwitchBenchmark.switch_statements           12  avgt    3   4.669 ±  1.455  ns/op
EnumSwitchBenchmark.switch_statements           24  avgt    3   6.538 ± 19.011  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                                 (branches)  Mode  Cnt   Score   Error  Units
StringSwitchBenchmark.chained_ifs                  3  avgt    3   4.894 ± 0.199  ns/op
StringSwitchBenchmark.chained_ifs                  6  avgt    3   7.371 ± 0.219  ns/op
StringSwitchBenchmark.chained_ifs                 12  avgt    3  23.854 ± 1.418  ns/op
StringSwitchBenchmark.chained_ifs                 24  avgt    3  39.396 ± 1.981  ns/op
StringSwitchBenchmark.switch_expressions           3  avgt    3  15.397 ± 1.240  ns/op
StringSwitchBenchmark.switch_expressions           6  avgt    3  17.517 ± 1.856  ns/op
StringSwitchBenchmark.switch_expressions          12  avgt    3  19.657 ± 1.801  ns/op
StringSwitchBenchmark.switch_expressions          24  avgt    3  20.788 ± 0.194  ns/op
StringSwitchBenchmark.switch_statements            3  avgt    3  13.380 ± 0.038  ns/op
StringSwitchBenchmark.switch_statements            6  avgt    3  16.970 ± 2.150  ns/op
StringSwitchBenchmark.switch_statements           12  avgt    3  19.071 ± 1.962  ns/op
StringSwitchBenchmark.switch_statements           24  avgt    3  21.142 ± 2.135  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                                 (branches)  Mode  Cnt   Score   Error  Units
StringSwitchBenchmark.chained_ifs                  3  avgt    3   6.425 ± 0.455  ns/op
StringSwitchBenchmark.chained_ifs                  6  avgt    3  13.403 ± 1.095  ns/op
StringSwitchBenchmark.chained_ifs                 12  avgt    3  23.327 ± 0.308  ns/op
StringSwitchBenchmark.chained_ifs                 24  avgt    3  42.937 ± 1.541  ns/op
StringSwitchBenchmark.switch_expressions           3  avgt    3   7.262 ± 0.504  ns/op
StringSwitchBenchmark.switch_expressions           6  avgt    3   9.338 ± 0.360  ns/op
StringSwitchBenchmark.switch_expressions          12  avgt    3  12.454 ± 0.845  ns/op
StringSwitchBenchmark.switch_expressions          24  avgt    3  15.071 ± 0.179  ns/op
StringSwitchBenchmark.switch_statements            3  avgt    3   7.278 ± 0.468  ns/op
StringSwitchBenchmark.switch_statements            6  avgt    3   9.349 ± 0.237  ns/op
StringSwitchBenchmark.switch_statements           12  avgt    3  12.584 ± 0.302  ns/op
StringSwitchBenchmark.switch_statements           24  avgt    3  14.741 ± 1.672  ns/op