### PR TITLE
Add StackTraceBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StackTraceBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StackTraceBenchmark.java
@@ -60,9 +60,9 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class StackTraceBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StackTraceBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/StackTraceBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.micro.compiler;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Assess the cost of producing an array of stack trace elements, each representing stack frame information printed by the printStackTrace() method.
+ * As a known fact, the costs of constructing a stack trace are proportional to the depth of the Java stack at the moment of exception instantiation.
+ * The stack traces pertain to exception object instances created using different approaches:
+ * - A global constant exception instance declared and initialized at the beginning of the program execution.
+ * - A global constant lambda supplier exception declared and initialized also at the beginning of the program execution.
+ * - A method-scoped exception declared and initialized when the execution reaches a certain stack depth within the running method.
+ * - A method-scoped exception (with the fillInStackTrace() method overridden) declared and initialized when the execution reaches a certain stack depth within the running method.
+ * - The Thread.currentThread() API when the execution reaches a certain stack depth within the running method.
+ *
+ * HotSpot-specific optimization flags:
+ * - -XX:±OmitStackTraceInFastThrow - By default, for 'hot' exceptions in the optimized code, the compiler may choose a faster approach using
+ * pre-allocated exceptions that do not include a stack trace.
+ * - -XX:±StackTraceInThrowable - By default, stack traces are included in exceptions; however, recording them might have a negative impact on performance.
+ *  This option allows the removal of stack traces from the throwable when an exception occurs.
+ *
+ * Note: some virtual machines may, under some circumstances, omit one or more stack frames from the stack trace.
+ * In the extreme case, a virtual machine that has no stack trace information concerning this throwable is permitted to return a zero-length array of stack trace elements.
+ *
+ * References:
+ * - https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/globals.hpp#L652-L656
+ * - https://shipilev.net/blog/2014/exceptional-performance
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class StackTraceBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*StackTraceBenchmark.*"
+  // Recommended command line options:
+  // - JVM options:
+  //     default: {-XX:+OmitStackTraceInFastThrow -XX:+StackTraceInThrowable}
+  //     omit stack traces: {-XX:-OmitStackTraceInFastThrow -XX:-StackTraceInThrowable}
+
+  private final Exception CONSTANT_EXCEPTION = new Exception();
+  private final Supplier<Exception> LAMBDA_EXCEPTION = () -> new Exception();
+
+  @Param({"1", "10", "100", "1000"})
+  int stackDepth;
+
+  @Benchmark
+  public StackTraceElement[] constant_exception() {
+    return constantException(stackDepth);
+  }
+
+  @Benchmark
+  public StackTraceElement[] lambda_exception() {
+    return lambdaException(stackDepth);
+  }
+
+  @Benchmark
+  public StackTraceElement[] new_exception() {
+    return newException(stackDepth);
+  }
+
+  @Benchmark
+  public StackTraceElement[] new_exception_override_fillInStackTrace() {
+    return newExceptionOverrideFillInStackTrace(stackDepth);
+  }
+
+  @Benchmark
+  public StackTraceElement[] current_thread() {
+    return currentThread(stackDepth);
+  }
+
+  private StackTraceElement[] constantException(int depth) {
+    if (depth == 0) {
+      return CONSTANT_EXCEPTION.getStackTrace();
+    }
+    return constantException(depth - 1);
+  }
+
+  private StackTraceElement[] lambdaException(int depth) {
+    if (depth == 0) {
+      return LAMBDA_EXCEPTION.get().getStackTrace();
+    }
+    return lambdaException(depth - 1);
+  }
+
+  private StackTraceElement[] newException(int depth) {
+    if (depth == 0) {
+      return new Exception().getStackTrace();
+    }
+    return newException(depth - 1);
+  }
+
+  private StackTraceElement[] newExceptionOverrideFillInStackTrace(int depth) {
+    if (depth == 0) {
+      return (new Exception() {
+            @Override
+            public Throwable fillInStackTrace() {
+              return this;
+            }
+          })
+          .getStackTrace();
+    }
+    return newExceptionOverrideFillInStackTrace(depth - 1);
+  }
+
+  private StackTraceElement[] currentThread(int depth) {
+    if (depth == 0) {
+      return Thread.currentThread().getStackTrace();
+    }
+    return currentThread(depth - 1);
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                                                    (stackDepth)  Mode  Cnt       Score         Error  Units
StackTraceBenchmark.constant_exception                                  1  avgt    3      66.178 ±      23.837  ns/op
StackTraceBenchmark.constant_exception                                 10  avgt    3      92.400 ±      13.086  ns/op
StackTraceBenchmark.constant_exception                                100  avgt    3     527.278 ±     354.055  ns/op
StackTraceBenchmark.constant_exception                               1000  avgt    3    3856.160 ±     406.307  ns/op
StackTraceBenchmark.current_thread                                      1  avgt    3   22496.784 ±    1582.142  ns/op
StackTraceBenchmark.current_thread                                     10  avgt    3   29177.649 ±    4155.523  ns/op
StackTraceBenchmark.current_thread                                    100  avgt    3   99419.164 ±    2822.802  ns/op
StackTraceBenchmark.current_thread                                   1000  avgt    3  810696.201 ±  298847.728  ns/op
StackTraceBenchmark.lambda_exception                                    1  avgt    3   21772.914 ±    4584.643  ns/op
StackTraceBenchmark.lambda_exception                                   10  avgt    3   29281.778 ±   17226.321  ns/op
StackTraceBenchmark.lambda_exception                                  100  avgt    3  102312.419 ±   62118.267  ns/op
StackTraceBenchmark.lambda_exception                                 1000  avgt    3  803761.410 ±  143868.509  ns/op
StackTraceBenchmark.new_exception                                       1  avgt    3   22498.260 ±   33216.759  ns/op
StackTraceBenchmark.new_exception                                      10  avgt    3   28136.280 ±    3278.498  ns/op
StackTraceBenchmark.new_exception                                     100  avgt    3   98413.302 ±   19635.317  ns/op
StackTraceBenchmark.new_exception                                    1000  avgt    3  893041.363 ± 1759331.313  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace             1  avgt    3     196.583 ±     556.578  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace            10  avgt    3     349.002 ±    1114.528  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace           100  avgt    3     877.441 ±     801.855  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace          1000  avgt    3    8016.618 ±    7634.287  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                                                    (stackDepth)  Mode  Cnt       Score        Error  Units
StackTraceBenchmark.constant_exception                                  1  avgt    3      90.893 ±     13.182  ns/op
StackTraceBenchmark.constant_exception                                 10  avgt    3      97.143 ±     19.304  ns/op
StackTraceBenchmark.constant_exception                                100  avgt    3     165.119 ±     27.481  ns/op
StackTraceBenchmark.constant_exception                               1000  avgt    3    1412.800 ±   5332.751  ns/op
StackTraceBenchmark.current_thread                                      1  avgt    3   30766.242 ±  30423.795  ns/op
StackTraceBenchmark.current_thread                                     10  avgt    3   42215.321 ± 158157.265  ns/op
StackTraceBenchmark.current_thread                                    100  avgt    3  141624.999 ± 630398.717  ns/op
StackTraceBenchmark.current_thread                                   1000  avgt    3  971903.774 ± 762390.956  ns/op
StackTraceBenchmark.lambda_exception                                    1  avgt    3   28685.451 ±  77539.543  ns/op
StackTraceBenchmark.lambda_exception                                   10  avgt    3   39152.359 ± 144344.063  ns/op
StackTraceBenchmark.lambda_exception                                  100  avgt    3  131127.827 ± 269463.739  ns/op
StackTraceBenchmark.lambda_exception                                 1000  avgt    3  916121.330 ± 705517.234  ns/op
StackTraceBenchmark.new_exception                                       1  avgt    3   24619.651 ±   7945.734  ns/op
StackTraceBenchmark.new_exception                                      10  avgt    3   31211.964 ±  50260.394  ns/op
StackTraceBenchmark.new_exception                                     100  avgt    3  122221.822 ± 164138.694  ns/op
StackTraceBenchmark.new_exception                                    1000  avgt    3  942935.610 ± 541108.840  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace             1  avgt    3     260.826 ±   1957.140  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace            10  avgt    3     240.994 ±   1237.788  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace           100  avgt    3     342.251 ±    943.236  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace          1000  avgt    3    1637.629 ±   3499.553  ns/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                                                    (stackDepth)  Mode  Cnt        Score         Error  Units
StackTraceBenchmark.constant_exception                                  1  avgt    3      137.066 ±    1320.008  ns/op
StackTraceBenchmark.constant_exception                                 10  avgt    3      178.770 ±     503.269  ns/op
StackTraceBenchmark.constant_exception                                100  avgt    3      428.208 ±     643.811  ns/op
StackTraceBenchmark.constant_exception                               1000  avgt    3     3793.812 ±     864.295  ns/op
StackTraceBenchmark.current_thread                                      1  avgt    3    41500.666 ±   48308.852  ns/op
StackTraceBenchmark.current_thread                                     10  avgt    3    57913.072 ±  140724.736  ns/op
StackTraceBenchmark.current_thread                                    100  avgt    3   251325.164 ±  763594.349  ns/op
StackTraceBenchmark.current_thread                                   1000  avgt    3  1961212.544 ± 3290484.555  ns/op
StackTraceBenchmark.lambda_exception                                    1  avgt    3    47255.684 ±  149483.534  ns/op
StackTraceBenchmark.lambda_exception                                   10  avgt    3    62523.509 ±   94443.099  ns/op
StackTraceBenchmark.lambda_exception                                  100  avgt    3   252410.268 ±  190418.650  ns/op
StackTraceBenchmark.lambda_exception                                 1000  avgt    3  2204130.140 ±  528472.318  ns/op
StackTraceBenchmark.new_exception                                       1  avgt    3    43889.200 ±   14753.741  ns/op
StackTraceBenchmark.new_exception                                      10  avgt    3    66094.061 ±   49698.696  ns/op
StackTraceBenchmark.new_exception                                     100  avgt    3   230767.964 ±  539415.183  ns/op
StackTraceBenchmark.new_exception                                    1000  avgt    3  1957333.315 ± 3291962.370  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace             1  avgt    3      160.324 ±     382.956  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace            10  avgt    3      264.242 ±    1021.102  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace           100  avgt    3     1447.468 ±    3853.709  ns/op
StackTraceBenchmark.new_exception_override_fillInStackTrace          1000  avgt    3    17696.926 ±   47047.083  ns/op

