### PR TITLE
Add RandomBenchmark(s)

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
@@ -54,7 +54,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class RandomGeneratorBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
@@ -52,8 +52,8 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1)
 @State(Scope.Benchmark)
 public class RandomGeneratorBenchmark {

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/RandomGeneratorBenchmark.java
@@ -1,0 +1,147 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.random;
+
+import java.util.concurrent.TimeUnit;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Assess various types of implementations for pseudorandom number generators (PRNGs), including jumpable PRNGs,
+ * and an additional class of splittable PRNG algorithms (LXM). The tested methods include ints, longs, doubles,
+ * nextBoolean, nextInt, nextLong, nextDouble, nextBytes, nextFloat, nextGaussian, and nextExponential.
+ *
+ * Please note that ThreadLocalRandom is not included in this assessment because the RandomGeneratorFactory
+ * lacks an implementation for it. Therefore, it is evaluated separately.
+ *
+ * JEP 356: Enhanced Pseudo-Random Number Generators was added in JDK 17
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class RandomGeneratorBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*RandomGeneratorBenchmark.*"
+
+  @Param("1024")
+  private int bytesSize;
+
+  @Param({
+    "L128X1024MixRandom",
+    "L128X128MixRandom",
+    "L128X256MixRandom",
+    "L32X64MixRandom",
+    "L64X1024MixRandom",
+    "L64X128MixRandom",
+    "L64X128StarStarRandom",
+    "L64X256MixRandom",
+    "Random",
+    "SecureRandom",
+    "SplittableRandom",
+    "Xoroshiro128PlusPlus",
+    "Xoshiro256PlusPlus"
+  })
+  private String generatorName;
+
+  private RandomGenerator randomGenerator;
+  private byte[] bytes;
+
+  @Setup
+  public void setup() {
+    bytes = new byte[bytesSize];
+    randomGenerator = RandomGeneratorFactory.of(generatorName).create(generatorName.hashCode());
+  }
+
+  @Benchmark
+  public boolean next_boolean() {
+    return randomGenerator.nextBoolean();
+  }
+
+  @Benchmark
+  public byte[] next_bytes() {
+    randomGenerator.nextBytes(bytes);
+    return bytes;
+  }
+
+  @Benchmark
+  public float next_float() {
+    return randomGenerator.nextFloat();
+  }
+
+  @Benchmark
+  public double next_double() {
+    return randomGenerator.nextDouble();
+  }
+
+  @Benchmark
+  public int next_int() {
+    return randomGenerator.nextInt();
+  }
+
+  @Benchmark
+  public long next_long() {
+    return randomGenerator.nextLong();
+  }
+
+  @Benchmark
+  public double next_gaussian() {
+    return randomGenerator.nextGaussian();
+  }
+
+  @Benchmark
+  public double next_exponential() {
+    return randomGenerator.nextExponential();
+  }
+
+  @Benchmark
+  public DoubleStream doubles() {
+    return randomGenerator.doubles(bytesSize);
+  }
+
+  @Benchmark
+  public IntStream ints() {
+    return randomGenerator.ints(bytesSize);
+  }
+
+  @Benchmark
+  public LongStream longs() {
+    return randomGenerator.longs(bytesSize);
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
@@ -45,8 +45,8 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1)
 @State(Scope.Benchmark)
 public class ThreadLocalRandomBenchmark {

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class ThreadLocalRandomBenchmark {
 

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/random/ThreadLocalRandomBenchmark.java
@@ -1,0 +1,122 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.random;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * Assess the implementation of ThreadLocalRandom for pseudorandom number generation. The evaluated methods encompass ints,
+ * longs, doubles, nextBoolean, nextInt, nextLong, nextDouble, nextBytes, nextFloat, nextGaussian, and nextExponential.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class ThreadLocalRandomBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*ThreadLocalRandomBenchmark.*"
+
+  @Param("1024")
+  private int bytesSize;
+
+  private final ThreadLocalRandom randomGenerator = ThreadLocalRandom.current();
+  private byte[] bytes;
+
+  @Setup
+  public void setup() {
+    bytes = new byte[bytesSize];
+  }
+
+  @Benchmark
+  public boolean next_boolean() {
+    return randomGenerator.nextBoolean();
+  }
+
+  @Benchmark
+  public byte[] next_bytes() {
+    randomGenerator.nextBytes(bytes);
+    return bytes;
+  }
+
+  @Benchmark
+  public float next_float() {
+    return randomGenerator.nextFloat();
+  }
+
+  @Benchmark
+  public double next_double() {
+    return randomGenerator.nextDouble();
+  }
+
+  @Benchmark
+  public int next_int() {
+    return randomGenerator.nextInt();
+  }
+
+  @Benchmark
+  public long next_long() {
+    return randomGenerator.nextLong();
+  }
+
+  @Benchmark
+  public double next_gaussian() {
+    return randomGenerator.nextGaussian();
+  }
+
+  @Benchmark
+  public double next_exponential() {
+    return randomGenerator.nextExponential();
+  }
+
+  @Benchmark
+  public DoubleStream doubles() {
+    return randomGenerator.doubles(bytesSize);
+  }
+
+  @Benchmark
+  public IntStream ints() {
+    return randomGenerator.ints(bytesSize);
+  }
+
+  @Benchmark
+  public LongStream longs() {
+    return randomGenerator.longs(bytesSize);
+  }
+}


### PR DESCRIPTION
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                                  (bytesSize)        (generatorName)  Mode  Cnt      Score      Error  Units
RandomGeneratorBenchmark.doubles                  1024     L128X1024MixRandom  avgt    3     46.858 ±  120.248  ns/op
RandomGeneratorBenchmark.doubles                  1024      L128X128MixRandom  avgt    3     48.462 ±   55.952  ns/op
RandomGeneratorBenchmark.doubles                  1024      L128X256MixRandom  avgt    3     32.221 ±    9.317  ns/op
RandomGeneratorBenchmark.doubles                  1024        L32X64MixRandom  avgt    3     31.392 ±   10.319  ns/op
RandomGeneratorBenchmark.doubles                  1024      L64X1024MixRandom  avgt    3     30.949 ±    7.209  ns/op
RandomGeneratorBenchmark.doubles                  1024       L64X128MixRandom  avgt    3     31.075 ±   18.340  ns/op
RandomGeneratorBenchmark.doubles                  1024  L64X128StarStarRandom  avgt    3     31.062 ±   15.549  ns/op
RandomGeneratorBenchmark.doubles                  1024       L64X256MixRandom  avgt    3     30.627 ±   10.741  ns/op
RandomGeneratorBenchmark.doubles                  1024                 Random  avgt    3     31.446 ±    8.684  ns/op
RandomGeneratorBenchmark.doubles                  1024           SecureRandom  avgt    3     30.851 ±    7.765  ns/op
RandomGeneratorBenchmark.doubles                  1024       SplittableRandom  avgt    3     30.467 ±    6.440  ns/op
RandomGeneratorBenchmark.doubles                  1024   Xoroshiro128PlusPlus  avgt    3     65.721 ±  109.850  ns/op
RandomGeneratorBenchmark.doubles                  1024     Xoshiro256PlusPlus  avgt    3     52.665 ±   11.783  ns/op
RandomGeneratorBenchmark.ints                     1024     L128X1024MixRandom  avgt    3     23.224 ±    3.134  ns/op
RandomGeneratorBenchmark.ints                     1024      L128X128MixRandom  avgt    3     23.407 ±    7.991  ns/op
RandomGeneratorBenchmark.ints                     1024      L128X256MixRandom  avgt    3     23.544 ±   12.214  ns/op
RandomGeneratorBenchmark.ints                     1024        L32X64MixRandom  avgt    3     23.397 ±    7.571  ns/op
RandomGeneratorBenchmark.ints                     1024      L64X1024MixRandom  avgt    3     23.751 ±   14.121  ns/op
RandomGeneratorBenchmark.ints                     1024       L64X128MixRandom  avgt    3     23.213 ±    5.251  ns/op
RandomGeneratorBenchmark.ints                     1024  L64X128StarStarRandom  avgt    3     22.985 ±    3.513  ns/op
RandomGeneratorBenchmark.ints                     1024       L64X256MixRandom  avgt    3     23.664 ±   17.278  ns/op
RandomGeneratorBenchmark.ints                     1024                 Random  avgt    3     23.314 ±    6.739  ns/op
RandomGeneratorBenchmark.ints                     1024           SecureRandom  avgt    3     23.033 ±    3.028  ns/op
RandomGeneratorBenchmark.ints                     1024       SplittableRandom  avgt    3     23.139 ±    6.086  ns/op
RandomGeneratorBenchmark.ints                     1024   Xoroshiro128PlusPlus  avgt    3     53.183 ±   12.326  ns/op
RandomGeneratorBenchmark.ints                     1024     Xoshiro256PlusPlus  avgt    3     53.351 ±    9.055  ns/op
RandomGeneratorBenchmark.longs                    1024     L128X1024MixRandom  avgt    3     24.568 ±   12.319  ns/op
RandomGeneratorBenchmark.longs                    1024      L128X128MixRandom  avgt    3     24.929 ±    9.492  ns/op
RandomGeneratorBenchmark.longs                    1024      L128X256MixRandom  avgt    3     24.812 ±   14.855  ns/op
RandomGeneratorBenchmark.longs                    1024        L32X64MixRandom  avgt    3     31.413 ±  109.243  ns/op
RandomGeneratorBenchmark.longs                    1024      L64X1024MixRandom  avgt    3     35.409 ±   51.380  ns/op
RandomGeneratorBenchmark.longs                    1024       L64X128MixRandom  avgt    3     42.642 ±  198.893  ns/op
RandomGeneratorBenchmark.longs                    1024  L64X128StarStarRandom  avgt    3     24.401 ±    6.847  ns/op
RandomGeneratorBenchmark.longs                    1024       L64X256MixRandom  avgt    3     26.266 ±   33.859  ns/op
RandomGeneratorBenchmark.longs                    1024                 Random  avgt    3     24.417 ±   12.664  ns/op
RandomGeneratorBenchmark.longs                    1024           SecureRandom  avgt    3     24.168 ±    6.327  ns/op
RandomGeneratorBenchmark.longs                    1024       SplittableRandom  avgt    3     24.818 ±   25.029  ns/op
RandomGeneratorBenchmark.longs                    1024   Xoroshiro128PlusPlus  avgt    3     67.516 ±  135.691  ns/op
RandomGeneratorBenchmark.longs                    1024     Xoshiro256PlusPlus  avgt    3     59.712 ±   83.929  ns/op
RandomGeneratorBenchmark.next_boolean             1024     L128X1024MixRandom  avgt    3     35.321 ±    8.881  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L128X128MixRandom  avgt    3     23.949 ±    6.399  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L128X256MixRandom  avgt    3     21.929 ±    2.945  ns/op
RandomGeneratorBenchmark.next_boolean             1024        L32X64MixRandom  avgt    3     10.093 ±    0.511  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L64X1024MixRandom  avgt    3     14.750 ±    5.428  ns/op
RandomGeneratorBenchmark.next_boolean             1024       L64X128MixRandom  avgt    3     10.220 ±    2.949  ns/op
RandomGeneratorBenchmark.next_boolean             1024  L64X128StarStarRandom  avgt    3      9.519 ±    1.601  ns/op
RandomGeneratorBenchmark.next_boolean             1024       L64X256MixRandom  avgt    3     12.002 ±    4.964  ns/op
RandomGeneratorBenchmark.next_boolean             1024                 Random  avgt    3     30.073 ±    2.107  ns/op
RandomGeneratorBenchmark.next_boolean             1024           SecureRandom  avgt    3    238.637 ±   70.291  ns/op
RandomGeneratorBenchmark.next_boolean             1024       SplittableRandom  avgt    3      6.244 ±    1.131  ns/op
RandomGeneratorBenchmark.next_boolean             1024   Xoroshiro128PlusPlus  avgt    3      7.808 ±    0.833  ns/op
RandomGeneratorBenchmark.next_boolean             1024     Xoshiro256PlusPlus  avgt    3      8.652 ±    1.426  ns/op
RandomGeneratorBenchmark.next_bytes               1024     L128X1024MixRandom  avgt    3   4496.583 ±  661.306  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L128X128MixRandom  avgt    3   3434.308 ±  768.977  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L128X256MixRandom  avgt    3   3261.242 ±  277.788  ns/op
RandomGeneratorBenchmark.next_bytes               1024        L32X64MixRandom  avgt    3   2726.219 ±  650.674  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L64X1024MixRandom  avgt    3   2366.815 ±  192.576  ns/op
RandomGeneratorBenchmark.next_bytes               1024       L64X128MixRandom  avgt    3   2109.176 ± 4713.391  ns/op
RandomGeneratorBenchmark.next_bytes               1024  L64X128StarStarRandom  avgt    3   1755.659 ±  299.528  ns/op
RandomGeneratorBenchmark.next_bytes               1024       L64X256MixRandom  avgt    3   2169.238 ±  362.122  ns/op
RandomGeneratorBenchmark.next_bytes               1024                 Random  avgt    3   8643.793 ± 1432.223  ns/op
RandomGeneratorBenchmark.next_bytes               1024           SecureRandom  avgt    3  53697.648 ± 4741.150  ns/op
RandomGeneratorBenchmark.next_bytes               1024       SplittableRandom  avgt    3   1561.943 ±  321.101  ns/op
RandomGeneratorBenchmark.next_bytes               1024   Xoroshiro128PlusPlus  avgt    3   1594.478 ±  906.645  ns/op
RandomGeneratorBenchmark.next_bytes               1024     Xoshiro256PlusPlus  avgt    3   1829.254 ±  290.028  ns/op
RandomGeneratorBenchmark.next_double              1024     L128X1024MixRandom  avgt    3     32.373 ±    8.774  ns/op
RandomGeneratorBenchmark.next_double              1024      L128X128MixRandom  avgt    3     20.976 ±    4.034  ns/op
RandomGeneratorBenchmark.next_double              1024      L128X256MixRandom  avgt    3     20.607 ±    7.079  ns/op
RandomGeneratorBenchmark.next_double              1024        L32X64MixRandom  avgt    3     16.612 ±    3.798  ns/op
RandomGeneratorBenchmark.next_double              1024      L64X1024MixRandom  avgt    3     14.287 ±    0.712  ns/op
RandomGeneratorBenchmark.next_double              1024       L64X128MixRandom  avgt    3     10.099 ±    0.748  ns/op
RandomGeneratorBenchmark.next_double              1024  L64X128StarStarRandom  avgt    3      9.348 ±    1.738  ns/op
RandomGeneratorBenchmark.next_double              1024       L64X256MixRandom  avgt    3     10.673 ±    2.225  ns/op
RandomGeneratorBenchmark.next_double              1024                 Random  avgt    3     58.697 ±    6.599  ns/op
RandomGeneratorBenchmark.next_double              1024           SecureRandom  avgt    3    826.891 ±   47.464  ns/op
RandomGeneratorBenchmark.next_double              1024       SplittableRandom  avgt    3      6.961 ±    1.087  ns/op
RandomGeneratorBenchmark.next_double              1024   Xoroshiro128PlusPlus  avgt    3      7.943 ±    1.171  ns/op
RandomGeneratorBenchmark.next_double              1024     Xoshiro256PlusPlus  avgt    3      8.785 ±    2.935  ns/op
RandomGeneratorBenchmark.next_exponential         1024     L128X1024MixRandom  avgt    3     38.145 ±    6.252  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L128X128MixRandom  avgt    3     26.742 ±    2.044  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L128X256MixRandom  avgt    3     25.813 ±    3.670  ns/op
RandomGeneratorBenchmark.next_exponential         1024        L32X64MixRandom  avgt    3     22.483 ±    3.741  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L64X1024MixRandom  avgt    3     18.538 ±    4.358  ns/op
RandomGeneratorBenchmark.next_exponential         1024       L64X128MixRandom  avgt    3     16.024 ±    2.431  ns/op
RandomGeneratorBenchmark.next_exponential         1024  L64X128StarStarRandom  avgt    3     14.717 ±    4.099  ns/op
RandomGeneratorBenchmark.next_exponential         1024       L64X256MixRandom  avgt    3     16.970 ±    2.527  ns/op
RandomGeneratorBenchmark.next_exponential         1024                 Random  avgt    3     61.328 ±    9.158  ns/op
RandomGeneratorBenchmark.next_exponential         1024           SecureRandom  avgt    3    848.022 ±  194.489  ns/op
RandomGeneratorBenchmark.next_exponential         1024       SplittableRandom  avgt    3     10.934 ±    0.602  ns/op
RandomGeneratorBenchmark.next_exponential         1024   Xoroshiro128PlusPlus  avgt    3      9.895 ±    2.059  ns/op
RandomGeneratorBenchmark.next_exponential         1024     Xoshiro256PlusPlus  avgt    3     10.551 ±    0.522  ns/op
RandomGeneratorBenchmark.next_float               1024     L128X1024MixRandom  avgt    3     35.706 ±   78.054  ns/op
RandomGeneratorBenchmark.next_float               1024      L128X128MixRandom  avgt    3     22.287 ±    8.041  ns/op
RandomGeneratorBenchmark.next_float               1024      L128X256MixRandom  avgt    3     20.402 ±    9.796  ns/op
RandomGeneratorBenchmark.next_float               1024        L32X64MixRandom  avgt    3     10.473 ±    0.462  ns/op
RandomGeneratorBenchmark.next_float               1024      L64X1024MixRandom  avgt    3     14.970 ±    1.361  ns/op
RandomGeneratorBenchmark.next_float               1024       L64X128MixRandom  avgt    3     10.692 ±    1.455  ns/op
RandomGeneratorBenchmark.next_float               1024  L64X128StarStarRandom  avgt    3      9.687 ±    1.966  ns/op
RandomGeneratorBenchmark.next_float               1024       L64X256MixRandom  avgt    3     10.716 ±    1.626  ns/op
RandomGeneratorBenchmark.next_float               1024                 Random  avgt    3     29.540 ±    3.914  ns/op
RandomGeneratorBenchmark.next_float               1024           SecureRandom  avgt    3    384.432 ±   39.180  ns/op
RandomGeneratorBenchmark.next_float               1024       SplittableRandom  avgt    3      6.860 ±    0.894  ns/op
RandomGeneratorBenchmark.next_float               1024   Xoroshiro128PlusPlus  avgt    3      8.217 ±    0.757  ns/op
RandomGeneratorBenchmark.next_float               1024     Xoshiro256PlusPlus  avgt    3      9.194 ±    1.021  ns/op
RandomGeneratorBenchmark.next_gaussian            1024     L128X1024MixRandom  avgt    3     42.789 ±    6.167  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L128X128MixRandom  avgt    3     31.362 ±    0.867  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L128X256MixRandom  avgt    3     29.845 ±   13.006  ns/op
RandomGeneratorBenchmark.next_gaussian            1024        L32X64MixRandom  avgt    3     25.504 ±    3.937  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L64X1024MixRandom  avgt    3     20.791 ±    1.731  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       L64X128MixRandom  avgt    3     19.310 ±    1.607  ns/op
RandomGeneratorBenchmark.next_gaussian            1024  L64X128StarStarRandom  avgt    3     17.946 ±    7.325  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       L64X256MixRandom  avgt    3     18.623 ±    2.376  ns/op
RandomGeneratorBenchmark.next_gaussian            1024                 Random  avgt    3    201.283 ±   15.019  ns/op
RandomGeneratorBenchmark.next_gaussian            1024           SecureRandom  avgt    3   1183.638 ±  112.352  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       SplittableRandom  avgt    3     14.239 ±    1.254  ns/op
RandomGeneratorBenchmark.next_gaussian            1024   Xoroshiro128PlusPlus  avgt    3     13.877 ±    2.665  ns/op
RandomGeneratorBenchmark.next_gaussian            1024     Xoshiro256PlusPlus  avgt    3     14.972 ±    2.544  ns/op
RandomGeneratorBenchmark.next_int                 1024     L128X1024MixRandom  avgt    3     31.457 ±    4.787  ns/op
RandomGeneratorBenchmark.next_int                 1024      L128X128MixRandom  avgt    3     21.223 ±    2.344  ns/op
RandomGeneratorBenchmark.next_int                 1024      L128X256MixRandom  avgt    3     19.322 ±    2.359  ns/op
RandomGeneratorBenchmark.next_int                 1024        L32X64MixRandom  avgt    3      9.439 ±    2.963  ns/op
RandomGeneratorBenchmark.next_int                 1024      L64X1024MixRandom  avgt    3     13.046 ±    1.808  ns/op
RandomGeneratorBenchmark.next_int                 1024       L64X128MixRandom  avgt    3      9.319 ±    1.760  ns/op
RandomGeneratorBenchmark.next_int                 1024  L64X128StarStarRandom  avgt    3      8.894 ±    4.390  ns/op
RandomGeneratorBenchmark.next_int                 1024       L64X256MixRandom  avgt    3     10.224 ±    2.082  ns/op
RandomGeneratorBenchmark.next_int                 1024                 Random  avgt    3     29.761 ±    0.454  ns/op
RandomGeneratorBenchmark.next_int                 1024           SecureRandom  avgt    3    410.252 ±   32.262  ns/op
RandomGeneratorBenchmark.next_int                 1024       SplittableRandom  avgt    3      5.417 ±    0.644  ns/op
RandomGeneratorBenchmark.next_int                 1024   Xoroshiro128PlusPlus  avgt    3      7.194 ±    0.584  ns/op
RandomGeneratorBenchmark.next_int                 1024     Xoshiro256PlusPlus  avgt    3      8.165 ±    0.640  ns/op
RandomGeneratorBenchmark.next_long                1024     L128X1024MixRandom  avgt    3     30.326 ±    4.344  ns/op
RandomGeneratorBenchmark.next_long                1024      L128X128MixRandom  avgt    3     20.620 ±    2.074  ns/op
RandomGeneratorBenchmark.next_long                1024      L128X256MixRandom  avgt    3     19.242 ±    1.372  ns/op
RandomGeneratorBenchmark.next_long                1024        L32X64MixRandom  avgt    3     15.844 ±    1.724  ns/op
RandomGeneratorBenchmark.next_long                1024      L64X1024MixRandom  avgt    3     12.517 ±    1.031  ns/op
RandomGeneratorBenchmark.next_long                1024       L64X128MixRandom  avgt    3      9.164 ±    0.857  ns/op
RandomGeneratorBenchmark.next_long                1024  L64X128StarStarRandom  avgt    3      8.370 ±    2.125  ns/op
RandomGeneratorBenchmark.next_long                1024       L64X256MixRandom  avgt    3      9.528 ±    3.113  ns/op
RandomGeneratorBenchmark.next_long                1024                 Random  avgt    3     59.111 ±    5.990  ns/op
RandomGeneratorBenchmark.next_long                1024           SecureRandom  avgt    3    830.658 ±  220.700  ns/op
RandomGeneratorBenchmark.next_long                1024       SplittableRandom  avgt    3      6.967 ±   15.115  ns/op
RandomGeneratorBenchmark.next_long                1024   Xoroshiro128PlusPlus  avgt    3      6.646 ±    3.005  ns/op
RandomGeneratorBenchmark.next_long                1024     Xoshiro256PlusPlus  avgt    3      7.871 ±    3.919  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                                  (bytesSize)        (generatorName)  Mode  Cnt      Score       Error  Units
RandomGeneratorBenchmark.doubles                  1024     L128X1024MixRandom  avgt    3     20.328 ±    14.819  ns/op
RandomGeneratorBenchmark.doubles                  1024      L128X128MixRandom  avgt    3     19.933 ±     0.922  ns/op
RandomGeneratorBenchmark.doubles                  1024      L128X256MixRandom  avgt    3     19.637 ±     2.583  ns/op
RandomGeneratorBenchmark.doubles                  1024        L32X64MixRandom  avgt    3     19.846 ±     1.370  ns/op
RandomGeneratorBenchmark.doubles                  1024      L64X1024MixRandom  avgt    3     20.364 ±    14.142  ns/op
RandomGeneratorBenchmark.doubles                  1024       L64X128MixRandom  avgt    3     19.783 ±     2.056  ns/op
RandomGeneratorBenchmark.doubles                  1024  L64X128StarStarRandom  avgt    3     19.903 ±     2.218  ns/op
RandomGeneratorBenchmark.doubles                  1024       L64X256MixRandom  avgt    3     19.523 ±     1.828  ns/op
RandomGeneratorBenchmark.doubles                  1024                 Random  avgt    3     19.730 ±     1.738  ns/op
RandomGeneratorBenchmark.doubles                  1024           SecureRandom  avgt    3     19.532 ±     1.271  ns/op
RandomGeneratorBenchmark.doubles                  1024       SplittableRandom  avgt    3     19.681 ±     2.982  ns/op
RandomGeneratorBenchmark.doubles                  1024   Xoroshiro128PlusPlus  avgt    3     34.583 ±     2.554  ns/op
RandomGeneratorBenchmark.doubles                  1024     Xoshiro256PlusPlus  avgt    3     34.259 ±     2.546  ns/op
RandomGeneratorBenchmark.ints                     1024     L128X1024MixRandom  avgt    3     19.400 ±     1.802  ns/op
RandomGeneratorBenchmark.ints                     1024      L128X128MixRandom  avgt    3     19.869 ±     9.530  ns/op
RandomGeneratorBenchmark.ints                     1024      L128X256MixRandom  avgt    3     19.536 ±     1.964  ns/op
RandomGeneratorBenchmark.ints                     1024        L32X64MixRandom  avgt    3     20.010 ±    11.684  ns/op
RandomGeneratorBenchmark.ints                     1024      L64X1024MixRandom  avgt    3     19.346 ±     1.276  ns/op
RandomGeneratorBenchmark.ints                     1024       L64X128MixRandom  avgt    3     19.463 ±     2.217  ns/op
RandomGeneratorBenchmark.ints                     1024  L64X128StarStarRandom  avgt    3     19.580 ±     1.650  ns/op
RandomGeneratorBenchmark.ints                     1024       L64X256MixRandom  avgt    3     19.210 ±     1.638  ns/op
RandomGeneratorBenchmark.ints                     1024                 Random  avgt    3     19.334 ±     2.198  ns/op
RandomGeneratorBenchmark.ints                     1024           SecureRandom  avgt    3     19.300 ±     2.191  ns/op
RandomGeneratorBenchmark.ints                     1024       SplittableRandom  avgt    3     19.076 ±     2.427  ns/op
RandomGeneratorBenchmark.ints                     1024   Xoroshiro128PlusPlus  avgt    3     34.467 ±     6.425  ns/op
RandomGeneratorBenchmark.ints                     1024     Xoshiro256PlusPlus  avgt    3     34.569 ±     5.061  ns/op
RandomGeneratorBenchmark.longs                    1024     L128X1024MixRandom  avgt    3     19.696 ±     1.311  ns/op
RandomGeneratorBenchmark.longs                    1024      L128X128MixRandom  avgt    3     19.714 ±     1.505  ns/op
RandomGeneratorBenchmark.longs                    1024      L128X256MixRandom  avgt    3     19.647 ±     2.615  ns/op
RandomGeneratorBenchmark.longs                    1024        L32X64MixRandom  avgt    3     19.951 ±     4.216  ns/op
RandomGeneratorBenchmark.longs                    1024      L64X1024MixRandom  avgt    3     20.317 ±     9.730  ns/op
RandomGeneratorBenchmark.longs                    1024       L64X128MixRandom  avgt    3     19.733 ±     1.479  ns/op
RandomGeneratorBenchmark.longs                    1024  L64X128StarStarRandom  avgt    3     19.592 ±     3.344  ns/op
RandomGeneratorBenchmark.longs                    1024       L64X256MixRandom  avgt    3     20.089 ±     8.618  ns/op
RandomGeneratorBenchmark.longs                    1024                 Random  avgt    3     19.603 ±     3.740  ns/op
RandomGeneratorBenchmark.longs                    1024           SecureRandom  avgt    3     19.683 ±     1.391  ns/op
RandomGeneratorBenchmark.longs                    1024       SplittableRandom  avgt    3     19.672 ±     2.578  ns/op
RandomGeneratorBenchmark.longs                    1024   Xoroshiro128PlusPlus  avgt    3     34.206 ±     3.473  ns/op
RandomGeneratorBenchmark.longs                    1024     Xoshiro256PlusPlus  avgt    3     35.153 ±    27.581  ns/op
RandomGeneratorBenchmark.next_boolean             1024     L128X1024MixRandom  avgt    3     29.302 ±     1.760  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L128X128MixRandom  avgt    3     18.239 ±     0.954  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L128X256MixRandom  avgt    3     16.687 ±     2.185  ns/op
RandomGeneratorBenchmark.next_boolean             1024        L32X64MixRandom  avgt    3      9.733 ±     0.109  ns/op
RandomGeneratorBenchmark.next_boolean             1024      L64X1024MixRandom  avgt    3     12.643 ±     0.783  ns/op
RandomGeneratorBenchmark.next_boolean             1024       L64X128MixRandom  avgt    3      9.983 ±     1.058  ns/op
RandomGeneratorBenchmark.next_boolean             1024  L64X128StarStarRandom  avgt    3      9.104 ±     0.730  ns/op
RandomGeneratorBenchmark.next_boolean             1024       L64X256MixRandom  avgt    3     10.519 ±     1.666  ns/op
RandomGeneratorBenchmark.next_boolean             1024                 Random  avgt    3     29.179 ±    15.764  ns/op
RandomGeneratorBenchmark.next_boolean             1024           SecureRandom  avgt    3    229.261 ±     9.221  ns/op
RandomGeneratorBenchmark.next_boolean             1024       SplittableRandom  avgt    3      6.527 ±     0.264  ns/op
RandomGeneratorBenchmark.next_boolean             1024   Xoroshiro128PlusPlus  avgt    3      7.848 ±     1.033  ns/op
RandomGeneratorBenchmark.next_boolean             1024     Xoshiro256PlusPlus  avgt    3      9.117 ±     2.708  ns/op
RandomGeneratorBenchmark.next_bytes               1024     L128X1024MixRandom  avgt    3   3706.752 ±   282.413  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L128X128MixRandom  avgt    3   2607.533 ±   437.991  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L128X256MixRandom  avgt    3   2647.698 ±   103.569  ns/op
RandomGeneratorBenchmark.next_bytes               1024        L32X64MixRandom  avgt    3   2230.094 ±   229.068  ns/op
RandomGeneratorBenchmark.next_bytes               1024      L64X1024MixRandom  avgt    3   1816.251 ±   154.224  ns/op
RandomGeneratorBenchmark.next_bytes               1024       L64X128MixRandom  avgt    3   1409.258 ±   561.256  ns/op
RandomGeneratorBenchmark.next_bytes               1024  L64X128StarStarRandom  avgt    3   1244.018 ±   167.311  ns/op
RandomGeneratorBenchmark.next_bytes               1024       L64X256MixRandom  avgt    3   1866.562 ±   264.364  ns/op
RandomGeneratorBenchmark.next_bytes               1024                 Random  avgt    3   8699.029 ±   535.378  ns/op
RandomGeneratorBenchmark.next_bytes               1024           SecureRandom  avgt    3  48885.054 ± 81846.191  ns/op
RandomGeneratorBenchmark.next_bytes               1024       SplittableRandom  avgt    3   1137.057 ±   196.700  ns/op
RandomGeneratorBenchmark.next_bytes               1024   Xoroshiro128PlusPlus  avgt    3   1115.626 ±   448.264  ns/op
RandomGeneratorBenchmark.next_bytes               1024     Xoshiro256PlusPlus  avgt    3   1341.884 ±   113.825  ns/op
RandomGeneratorBenchmark.next_double              1024     L128X1024MixRandom  avgt    3     27.797 ±     3.703  ns/op
RandomGeneratorBenchmark.next_double              1024      L128X128MixRandom  avgt    3     18.264 ±     0.934  ns/op
RandomGeneratorBenchmark.next_double              1024      L128X256MixRandom  avgt    3     16.903 ±     7.135  ns/op
RandomGeneratorBenchmark.next_double              1024        L32X64MixRandom  avgt    3     16.627 ±     1.594  ns/op
RandomGeneratorBenchmark.next_double              1024      L64X1024MixRandom  avgt    3     12.332 ±     1.523  ns/op
RandomGeneratorBenchmark.next_double              1024       L64X128MixRandom  avgt    3      9.819 ±     1.216  ns/op
RandomGeneratorBenchmark.next_double              1024  L64X128StarStarRandom  avgt    3      9.109 ±     1.347  ns/op
RandomGeneratorBenchmark.next_double              1024       L64X256MixRandom  avgt    3     10.559 ±     0.599  ns/op
RandomGeneratorBenchmark.next_double              1024                 Random  avgt    3     57.763 ±     5.712  ns/op
RandomGeneratorBenchmark.next_double              1024           SecureRandom  avgt    3    760.218 ±    91.184  ns/op
RandomGeneratorBenchmark.next_double              1024       SplittableRandom  avgt    3      7.502 ±     0.345  ns/op
RandomGeneratorBenchmark.next_double              1024   Xoroshiro128PlusPlus  avgt    3      7.487 ±     1.511  ns/op
RandomGeneratorBenchmark.next_double              1024     Xoshiro256PlusPlus  avgt    3      9.036 ±     0.631  ns/op
RandomGeneratorBenchmark.next_exponential         1024     L128X1024MixRandom  avgt    3     30.951 ±     6.236  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L128X128MixRandom  avgt    3     21.789 ±     1.453  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L128X256MixRandom  avgt    3     21.423 ±     1.464  ns/op
RandomGeneratorBenchmark.next_exponential         1024        L32X64MixRandom  avgt    3     19.608 ±     1.441  ns/op
RandomGeneratorBenchmark.next_exponential         1024      L64X1024MixRandom  avgt    3     15.904 ±     1.133  ns/op
RandomGeneratorBenchmark.next_exponential         1024       L64X128MixRandom  avgt    3     12.411 ±     0.672  ns/op
RandomGeneratorBenchmark.next_exponential         1024  L64X128StarStarRandom  avgt    3     10.606 ±     1.559  ns/op
RandomGeneratorBenchmark.next_exponential         1024       L64X256MixRandom  avgt    3     13.547 ±     1.064  ns/op
RandomGeneratorBenchmark.next_exponential         1024                 Random  avgt    3     61.706 ±     9.098  ns/op
RandomGeneratorBenchmark.next_exponential         1024           SecureRandom  avgt    3    805.186 ±   304.285  ns/op
RandomGeneratorBenchmark.next_exponential         1024       SplittableRandom  avgt    3      8.708 ±     0.282  ns/op
RandomGeneratorBenchmark.next_exponential         1024   Xoroshiro128PlusPlus  avgt    3      9.412 ±     4.074  ns/op
RandomGeneratorBenchmark.next_exponential         1024     Xoshiro256PlusPlus  avgt    3     10.232 ±     3.725  ns/op
RandomGeneratorBenchmark.next_float               1024     L128X1024MixRandom  avgt    3     28.526 ±     3.450  ns/op
RandomGeneratorBenchmark.next_float               1024      L128X128MixRandom  avgt    3     18.448 ±     4.237  ns/op
RandomGeneratorBenchmark.next_float               1024      L128X256MixRandom  avgt    3     17.023 ±     0.696  ns/op
RandomGeneratorBenchmark.next_float               1024        L32X64MixRandom  avgt    3      9.980 ±     1.335  ns/op
RandomGeneratorBenchmark.next_float               1024      L64X1024MixRandom  avgt    3     15.529 ±    32.613  ns/op
RandomGeneratorBenchmark.next_float               1024       L64X128MixRandom  avgt    3     10.135 ±     1.870  ns/op
RandomGeneratorBenchmark.next_float               1024  L64X128StarStarRandom  avgt    3      8.932 ±     1.445  ns/op
RandomGeneratorBenchmark.next_float               1024       L64X256MixRandom  avgt    3     11.031 ±     0.746  ns/op
RandomGeneratorBenchmark.next_float               1024                 Random  avgt    3     29.488 ±    12.805  ns/op
RandomGeneratorBenchmark.next_float               1024           SecureRandom  avgt    3    348.421 ±    49.035  ns/op
RandomGeneratorBenchmark.next_float               1024       SplittableRandom  avgt    3      6.842 ±     1.472  ns/op
RandomGeneratorBenchmark.next_float               1024   Xoroshiro128PlusPlus  avgt    3      8.228 ±     0.631  ns/op
RandomGeneratorBenchmark.next_float               1024     Xoshiro256PlusPlus  avgt    3      9.413 ±     1.197  ns/op
RandomGeneratorBenchmark.next_gaussian            1024     L128X1024MixRandom  avgt    3     32.334 ±     0.878  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L128X128MixRandom  avgt    3     22.256 ±     5.872  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L128X256MixRandom  avgt    3     22.846 ±     2.981  ns/op
RandomGeneratorBenchmark.next_gaussian            1024        L32X64MixRandom  avgt    3     20.927 ±    30.475  ns/op
RandomGeneratorBenchmark.next_gaussian            1024      L64X1024MixRandom  avgt    3     17.354 ±     5.890  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       L64X128MixRandom  avgt    3     12.574 ±     1.027  ns/op
RandomGeneratorBenchmark.next_gaussian            1024  L64X128StarStarRandom  avgt    3     11.154 ±     0.944  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       L64X256MixRandom  avgt    3     13.401 ±     0.637  ns/op
RandomGeneratorBenchmark.next_gaussian            1024                 Random  avgt    3    193.572 ±     4.882  ns/op
RandomGeneratorBenchmark.next_gaussian            1024           SecureRandom  avgt    3   1096.320 ±   145.286  ns/op
RandomGeneratorBenchmark.next_gaussian            1024       SplittableRandom  avgt    3     10.056 ±     0.535  ns/op
RandomGeneratorBenchmark.next_gaussian            1024   Xoroshiro128PlusPlus  avgt    3      9.072 ±     1.987  ns/op
RandomGeneratorBenchmark.next_gaussian            1024     Xoshiro256PlusPlus  avgt    3     10.726 ±     3.871  ns/op
RandomGeneratorBenchmark.next_int                 1024     L128X1024MixRandom  avgt    3     27.389 ±     0.713  ns/op
RandomGeneratorBenchmark.next_int                 1024      L128X128MixRandom  avgt    3     18.562 ±     0.645  ns/op
RandomGeneratorBenchmark.next_int                 1024      L128X256MixRandom  avgt    3     15.772 ±     2.239  ns/op
RandomGeneratorBenchmark.next_int                 1024        L32X64MixRandom  avgt    3     11.762 ±    27.153  ns/op
RandomGeneratorBenchmark.next_int                 1024      L64X1024MixRandom  avgt    3     11.938 ±     2.263  ns/op
RandomGeneratorBenchmark.next_int                 1024       L64X128MixRandom  avgt    3      9.961 ±    11.672  ns/op
RandomGeneratorBenchmark.next_int                 1024  L64X128StarStarRandom  avgt    3      9.047 ±     4.032  ns/op
RandomGeneratorBenchmark.next_int                 1024       L64X256MixRandom  avgt    3     11.564 ±     7.970  ns/op
RandomGeneratorBenchmark.next_int                 1024                 Random  avgt    3     31.772 ±    40.033  ns/op
RandomGeneratorBenchmark.next_int                 1024           SecureRandom  avgt    3    366.280 ±    27.224  ns/op
RandomGeneratorBenchmark.next_int                 1024       SplittableRandom  avgt    3      5.632 ±     0.370  ns/op
RandomGeneratorBenchmark.next_int                 1024   Xoroshiro128PlusPlus  avgt    3      7.005 ±     2.266  ns/op
RandomGeneratorBenchmark.next_int                 1024     Xoshiro256PlusPlus  avgt    3      8.620 ±     0.450  ns/op
RandomGeneratorBenchmark.next_long                1024     L128X1024MixRandom  avgt    3     27.312 ±     2.196  ns/op
RandomGeneratorBenchmark.next_long                1024      L128X128MixRandom  avgt    3     17.095 ±     3.286  ns/op
RandomGeneratorBenchmark.next_long                1024      L128X256MixRandom  avgt    3     15.794 ±     6.109  ns/op
RandomGeneratorBenchmark.next_long                1024        L32X64MixRandom  avgt    3     15.060 ±     2.844  ns/op
RandomGeneratorBenchmark.next_long                1024      L64X1024MixRandom  avgt    3     10.493 ±     2.277  ns/op
RandomGeneratorBenchmark.next_long                1024       L64X128MixRandom  avgt    3      8.921 ±     2.324  ns/op
RandomGeneratorBenchmark.next_long                1024  L64X128StarStarRandom  avgt    3      8.562 ±     5.640  ns/op
RandomGeneratorBenchmark.next_long                1024       L64X256MixRandom  avgt    3     10.350 ±     4.011  ns/op
RandomGeneratorBenchmark.next_long                1024                 Random  avgt    3     59.400 ±    10.513  ns/op
RandomGeneratorBenchmark.next_long                1024           SecureRandom  avgt    3    754.546 ±    73.462  ns/op
RandomGeneratorBenchmark.next_long                1024       SplittableRandom  avgt    3      5.864 ±     0.538  ns/op
RandomGeneratorBenchmark.next_long                1024   Xoroshiro128PlusPlus  avgt    3      6.316 ±     1.791  ns/op
RandomGeneratorBenchmark.next_long                1024     Xoshiro256PlusPlus  avgt    3      7.959 ±     1.190  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224
VM invoker: /usr/lib/jvm/openjdk-17.0.7/bin/java

Benchmark                                    (bytesSize)  Mode  Cnt     Score     Error  Units
ThreadLocalRandomBenchmark.doubles                  1024  avgt    3    24.227 ±   1.042  ns/op
ThreadLocalRandomBenchmark.ints                     1024  avgt    3    23.334 ±   0.240  ns/op
ThreadLocalRandomBenchmark.longs                    1024  avgt    3    24.104 ±   1.952  ns/op
ThreadLocalRandomBenchmark.next_boolean             1024  avgt    3     5.457 ±   0.151  ns/op
ThreadLocalRandomBenchmark.next_bytes               1024  avgt    3  3639.941 ± 755.745  ns/op
ThreadLocalRandomBenchmark.next_double              1024  avgt    3    11.004 ±   0.102  ns/op
ThreadLocalRandomBenchmark.next_exponential         1024  avgt    3    11.935 ±   0.266  ns/op
ThreadLocalRandomBenchmark.next_float               1024  avgt    3     6.441 ±   0.152  ns/op
ThreadLocalRandomBenchmark.next_gaussian            1024  avgt    3   131.949 ±   3.221  ns/op
ThreadLocalRandomBenchmark.next_int                 1024  avgt    3     5.295 ±   0.209  ns/op
ThreadLocalRandomBenchmark.next_long                1024  avgt    3     5.488 ±   0.383  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                                    (bytesSize)  Mode  Cnt     Score     Error  Units
ThreadLocalRandomBenchmark.doubles                  1024  avgt    3    20.722 ±   3.760  ns/op
ThreadLocalRandomBenchmark.ints                     1024  avgt    3    20.278 ±   2.942  ns/op
ThreadLocalRandomBenchmark.longs                    1024  avgt    3    21.111 ±  11.580  ns/op
ThreadLocalRandomBenchmark.next_boolean             1024  avgt    3     6.186 ±   2.285  ns/op
ThreadLocalRandomBenchmark.next_bytes               1024  avgt    3  3788.086 ± 730.934  ns/op
ThreadLocalRandomBenchmark.next_double              1024  avgt    3    11.892 ±   0.807  ns/op
ThreadLocalRandomBenchmark.next_exponential         1024  avgt    3     9.695 ±   0.443  ns/op
ThreadLocalRandomBenchmark.next_float               1024  avgt    3     6.889 ±   3.474  ns/op
ThreadLocalRandomBenchmark.next_gaussian            1024  avgt    3   132.973 ±  53.998  ns/op
ThreadLocalRandomBenchmark.next_int                 1024  avgt    3     5.718 ±   2.418  ns/op
ThreadLocalRandomBenchmark.next_long                1024  avgt    3     6.080 ±   2.387  ns/op
