### PR TITLE
Add UUID benchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/uuid/UUIDBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/uuid/UUIDBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * JVM Performance Benchmarks
+ *
+ * Copyright (C) 2019 - 2023 Ionut Balosin
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ionutbalosin.jvm.performance.benchmarks.macro.uuid;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/*
+ * It measures the performance of different operations related to UUIDs (Universally Unique Identifiers):
+ * - from_string(): Creates UUID objects from their string representations.
+ * - to_string(): Converts UUID objects to their string representations.
+ * - from_bytes(): Creates UUID objects from their byte representations.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class UUIDBenchmark {
+
+  // $ java -jar */*/benchmarks.jar ".*UUIDBenchmark.*"
+
+  private final int SIZE = 512;
+
+  private UUID[] uuids;
+  private String[] uuidStrings;
+  private byte[][] uuidBytes;
+  private int offsetIdx;
+
+  @Setup
+  public void setup() {
+    offsetIdx = 0;
+    uuids = new UUID[SIZE];
+    uuidStrings = new String[SIZE];
+    uuidBytes = new byte[SIZE][];
+
+    for (int i = 0; i < SIZE; i++) {
+      final UUID uuid = UUID.randomUUID();
+
+      this.uuids[i] = uuid;
+      this.uuidStrings[i] = uuid.toString();
+      this.uuidBytes[i] = uuid.toString().getBytes();
+    }
+  }
+
+  @Benchmark
+  public UUID from_string() {
+    final int position = nextPosition();
+    return UUID.fromString(uuidStrings[position]);
+  }
+
+  @Benchmark
+  public String to_string() {
+    final int position = nextPosition();
+    return uuids[position].toString();
+  }
+
+  @Benchmark
+  public UUID from_bytes() {
+    final int position = nextPosition();
+    return UUID.nameUUIDFromBytes(uuidBytes[position]);
+  }
+
+  private int nextPosition() {
+    if (++offsetIdx >= SIZE) {
+      offsetIdx = 0;
+    }
+
+    return offsetIdx;
+  }
+}

--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/uuid/UUIDBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/macro/uuid/UUIDBenchmark.java
@@ -43,9 +43,9 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 5)
 @State(Scope.Benchmark)
 public class UUIDBenchmark {
 

--- a/settings/benchmarks-suite-jdk21.json
+++ b/settings/benchmarks-suite-jdk21.json
@@ -320,6 +320,9 @@
       "name": "URLClassLoaderBenchmark"
     },
     {
+      "name": "UUIDBenchmark"
+    },
+    {
       "name": "VarArgsBenchmark"
     },
     {


### PR DESCRIPTION
JMH version: 1.37
VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-224

Benchmark                  Mode  Cnt     Score      Error  Units
UUIDBenchmark.from_bytes   avgt    3  1012.132 ± 4516.168  ns/op
UUIDBenchmark.from_string  avgt    3    80.820 ±    1.235  ns/op
UUIDBenchmark.to_string    avgt    3    68.148 ±    5.201  ns/op

---

VM version: JDK 17.0.7, Java HotSpot(TM) 64-Bit Server VM, 17.0.7+8-LTS-jvmci-23.0-b12
VM invoker: /usr/lib/jvm/graalvm-ee-jdk-17.0.7+8-LTS-jvmci-23.0-b12/bin/java

Benchmark                  Mode  Cnt    Score     Error  Units
UUIDBenchmark.from_bytes   avgt    3  586.390 ± 516.493  ns/op
UUIDBenchmark.from_string  avgt    3   81.734 ±  76.678  ns/op
UUIDBenchmark.to_string    avgt    3  111.106 ± 192.458  ns/op

---

VM version: JDK 17.0.7, Zing 64-Bit Tiered VM, 17.0.7-zing_23.04.0.0-b2-product-linux-X86_64
VM invoker: /usr/lib/jvm/zing23.04.0.0-2-jdk17.0.7-linux_x64/bin/java

Benchmark                  Mode  Cnt    Score      Error  Units
UUIDBenchmark.from_bytes   avgt    3  581.951 ± 1370.742  ns/op
UUIDBenchmark.from_string  avgt    3   75.973 ±   39.612  ns/op
UUIDBenchmark.to_string    avgt    3   58.407 ±   78.848  ns/op