### PR TITLE
Fix FalseSharingBenchmark

### DIFF
--- a/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/FalseSharingBenchmark.java
+++ b/benchmarks/src/main/java/com/ionutbalosin/jvm/performance/benchmarks/micro/compiler/FalseSharingBenchmark.java
@@ -98,21 +98,23 @@ public class FalseSharingBenchmark {
   }
 
   public static class ManualPaddingState0 {
+    // Superclass fields are typically laid out first.
     long l1;
   }
 
   public static class ManualPaddingState1 extends ManualPaddingState0 {
-    long l3, l4, l5, l6;
-    long l31, l41, l51, l61;
+    long p01, p02, p03, p04;
+    long p11, p12, p13, p14;
   }
 
   public static class ManualPaddingState2 extends ManualPaddingState1 {
+    // Subclass fields are typically  laid out last.
     long l2;
   }
 
   public static class ManualPaddingState3 extends ManualPaddingState2 {
-    long l7, l8, l9, l10;
-    long l71, l81, l91, l101;
+    long q01, q02, q03, q04;
+    long q11, q12, q13, q14;
   }
 
   @State(Scope.Group)
@@ -132,11 +134,14 @@ public class FalseSharingBenchmark {
 
   @State(Scope.Group)
   public static class ArrayState {
-    // The first 7 elements of the array will live on the same cache line.
-    // The 8th element will land on the next line.
-    // This benchmark will be slower than the others since it requires an extra load for the array
-    // field.
-    long[] arr = new long[16];
+    // In general, the cache line size is 64 bytes, but on some architectures
+    // (e.g., z/Architecture), it is significantly larger (e.g., 256 bytes).
+    // To account for these scenarios, we include a padding of 256 bytes between the first and
+    // second fields, which is considered sufficient.
+    //
+    // Note: this benchmark may be slower than others due to the additional load required for the
+    // array field.
+    long[] arr = new long[64];
   }
 
   @Benchmark
@@ -148,6 +153,6 @@ public class FalseSharingBenchmark {
   @Benchmark
   @Group("array_pad")
   public long writer(ArrayState arrayState) {
-    return arrayState.arr[7]++;
+    return arrayState.arr[32]++;
   }
 }


### PR DESCRIPTION
New results:

JMH version: 1.37
VM version: JDK 21, OpenJDK 64-Bit Server VM, 21+35-2513
VM invoker: /usr/lib/jvm/openjdk-21/bin/java

Benchmark                                Mode  Cnt   Score   Error  Units
FalseSharingBenchmark.array_pad          avgt    6   4.096 ± 0.012  ns/op
FalseSharingBenchmark.array_pad:reader   avgt    6   3.075 ± 0.008  ns/op
FalseSharingBenchmark.array_pad:writer   avgt    6   5.118 ± 0.017  ns/op

FalseSharingBenchmark.baseline           avgt    6   7.713 ± 3.791  ns/op
FalseSharingBenchmark.baseline:reader    avgt    6  10.274 ± 7.569  ns/op
FalseSharingBenchmark.baseline:writer    avgt    6   5.153 ± 0.027  ns/op

FalseSharingBenchmark.contended          avgt    6   3.581 ± 0.012  ns/op
FalseSharingBenchmark.contended:reader   avgt    6   2.051 ± 0.015  ns/op
FalseSharingBenchmark.contended:writer   avgt    6   5.111 ± 0.018  ns/op

FalseSharingBenchmark.manual_pad         avgt    6   3.648 ± 0.182  ns/op
FalseSharingBenchmark.manual_pad:reader  avgt    6   2.191 ± 0.352  ns/op
FalseSharingBenchmark.manual_pad:writer  avgt    6   5.104 ± 0.021  ns/op

-- 
It looks the errors are very small (as expected), except the baseline